### PR TITLE
Remove once_cell_try feature and move to stable channel

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -12,21 +12,18 @@ pub(crate) struct Config<'a> {
 static CONFIG: OnceLock<Config> = OnceLock::new();
 
 pub(crate) fn build_config() -> Result<&'static Config<'static>, Error> {
-    CONFIG.get_or_try_init(|| {
+    let home_dir = std::env::var("HOME").map_err(|_| {
+        log::error!("Failed to get $HOME");
+
+        Error::new(
+            "$HOME is missing",
+            Some("Your shell might not be supported."),
+        )
+    })?;
+
+    Ok(CONFIG.get_or_init(|| {
         let api_base =
             option_env!("KINETICS_API_BASE").unwrap_or("https://backend.usekinetics.com/");
-
-        let home_dir = match std::env::var("HOME") {
-            Ok(home_dir) => home_dir,
-            Err(_) => {
-                log::error!("Failed to get $HOME");
-
-                return Err(Error::new(
-                    "$HOME is missing",
-                    Some("Your shell might not be supported."),
-                ));
-            }
-        };
 
         let build_path_raw = Path::new(&home_dir).join(".kinetics");
 
@@ -47,12 +44,12 @@ pub(crate) fn build_config() -> Result<&'static Config<'static>, Error> {
                 .into_boxed_str(),
         );
 
-        Ok(Config {
+        Config {
             api_base,
             build_path,
             credentials_path,
-        })
-    })
+        }
+    }))
 }
 
 pub fn api_url(path: &str) -> String {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(once_cell_try)]
 pub mod build;
 pub mod cli;
 pub mod client;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(once_cell_try)]
 mod build;
 mod cli;
 mod client;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2025-02-03"


### PR DESCRIPTION
Move the fallible logic outside the `OnceLock`. This way the `$HOME` var is checked in each `build_config` call, but allows for stable channel use.