### PR TITLE
Update examples ref in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ tokio = "1.45.0"
 [workspace]
 resolver = "2"
 
-members = ["cli", "example", "macro", "parser"]
+members = ["cli", "examples", "macro", "parser"]


### PR DESCRIPTION
Fix incorrect member reference and restore the workspace (without the fix `rust-analyzer` and all cross-references caused failures).