### PR TITLE
Implement individual functions deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,19 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.3",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.77.0"
+version = "1.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc975e44b2093f682111c971f26341f9e54458a5241e4cfef73470f8c98f71b"
+checksum = "c3e30c5374787c7ec96b290e39a1b565c9508fee443dabcabf903ff157598fab"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -282,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "1.70.0"
+version = "1.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b742e0981caafc34a57b36d6e492786e2a11638766f49e1c92dec1b55f33d16b"
+checksum = "e7c66032c543428209106e3a104402289d9f18f77c7eb3de8f6e165256c42c38"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -446,7 +433,7 @@ dependencies = [
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tracing",
 ]
 
@@ -570,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "aws_lambda_events"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ddb91585253ccc85be3f2e0d5635529efdeadaf8a1da3230b433d3bbe43648"
+checksum = "144ec7565561115498a288850cc6a42b279e09b6c4b88f623eecb9c8ca96c08c"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -600,7 +587,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -777,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -787,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -826,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e1761c0e16f8883bbbb8ce5990867f4f06bf11a0253da6495a04ce4b6ef0ec"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -841,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ddd8d5bfda1e11a501d0a7303f3bfed9aa632ebdb859be40d0fd70478ed70d5"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
 dependencies = [
  "once_cell",
  "owo-colors",
@@ -1614,22 +1601,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1826,6 +1819,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1928,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics-macro"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kinetics-parser",
  "syn",
@@ -1936,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics-parser"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "color-eyre",
  "syn",
@@ -1944,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b470cea1ec37b96e9543870a33c1f4b9e243754fe5892668efa3125ea12784"
+checksum = "8dfc9f1bd9a56576319c1fe37f84e8551c9f9757f7f2307aa03c5b5d4a3c4d1c"
 dependencies = [
  "aws_lambda_events",
  "base64 0.22.1",
@@ -1971,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed49669d6430292aead991e19bf13153135a884f916e68f32997c951af637ebe"
+checksum = "c64945a7a718d04acbbd06fa8acdc37576f4dfbd8982932365b72907e7b2b27e"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -1992,16 +1995,16 @@ dependencies = [
  "serde_path_to_error",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tracing",
 ]
 
 [[package]]
 name = "lambda_runtime_api_client"
-version = "0.11.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90a10f094475a34a04da2be11686c4dcfe214d93413162db9ffdff3d3af293a"
+checksum = "df2589b440f900f61fc6d5cd26f71f0e75dcc7610bdbb88a56f0d308e1c35b42"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2012,7 +2015,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "tokio",
- "tower 0.4.13",
+ "tower",
  "tower-service",
  "tracing",
  "tracing-subscriber",
@@ -2043,7 +2046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2293,12 +2296,12 @@ checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "papergrid"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30268a8d20c2c0d126b2b6610ab405f16517f6ba9f244d8c59ac2c512a8a1ce7"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
 dependencies = [
- "ahash",
  "bytecount",
+ "fnv",
  "unicode-width",
 ]
 
@@ -2322,7 +2325,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2420,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2487,20 +2490,19 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -2508,11 +2510,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -2576,9 +2578,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2602,21 +2604,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -2719,7 +2720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -2743,15 +2744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -2927,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -3146,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228d124371171cd39f0f454b58f73ddebeeef3cef3207a82ffea1c29465aea43"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
 dependencies = [
  "papergrid",
  "tabled_derive",
@@ -3253,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3336,9 +3328,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3348,18 +3340,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -3371,24 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3401,6 +3378,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3496,9 +3491,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 dependencies = [
  "rand",
 ]
@@ -3775,7 +3770,7 @@ dependencies = [
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.0",
+ "windows-strings",
 ]
 
 [[package]]
@@ -3808,38 +3803,29 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
 dependencies = [
+ "windows-link",
  "windows-result",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -3850,7 +3836,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3859,7 +3845,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3868,30 +3854,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3901,22 +3871,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3925,22 +3883,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3949,22 +3895,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3973,22 +3907,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics-macro"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "kinetics-parser",
  "syn",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics-parser"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "color-eyre",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics-macro"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "kinetics-parser",
  "syn",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics-parser"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "color-eyre",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.dependencies]
-toml = "0.8.22"
-tokio = "1.45.0"
+toml = "0.8.23"
+tokio = "1.45.1"
 
 [workspace]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ kinetics invoke LibEndpoint
 # deployed to kinetics
 vim Cargo.toml
 
-# 7. Deploy to the cloud
+# 7. Deploy the entire project to the cloud
 kinetics deploy
+
+# 8. Alternatively you can deploy only selected functions
+kinetics deploy --functions BasicCronCron,BasicWorkerWorker
 ```
 
 > Kinetics is currently in ⚠️ **active development** and may contain bugs or result in unexpected behavior. The service is free for the first **100,000 invocations** of your functions, regardless of the type of workload.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kinetics"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2021"
 description = "Kinetics is a hosting platform for Rust applications that allows you to deploy all types of workloads by writing **only Rust code**."
 license = "Apache-2.0 OR MIT"
@@ -41,6 +41,6 @@ crossterm = "0.29.0"
 async-trait = "0.1.88"
 log = "0.4.27"
 env_logger = "0.11.8"
-kinetics-parser = { path = "../parser", version = "0.3.6" }
+kinetics-parser = { path = "../parser", version = "0.4.0" }
 tabled = "0.20.0"
 terminal_size = "0.4.2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,32 +15,32 @@ path = "src/main.rs"
 
 [dependencies]
 aws-config = "1.6.3"
-aws-sdk-dynamodb = "1.77.0"
+aws-sdk-dynamodb = "1.79.0"
 chrono = { version = "0.4.41", features = ["serde"] }
 uuid = { version = "1.17.0", features = ["v4"] }
-clap = { version = "4.5.38", features = ["derive"] }
+clap = { version = "4.5.39", features = ["derive"] }
 eyre = "0.6.12"
 regex = "1.11.1"
 walkdir = "2.5.0"
 zip = "4.0.0"
 tokio = { workspace = true, features = ["full"] }
 toml = { workspace = true }
-toml_edit = "0.22.26"
+toml_edit = "0.22.27"
 rust_dotenv = "0.1.2"
-reqwest = { version = "0.12.15", features = ["json", "blocking"] }
+reqwest = { version = "0.12.19", features = ["json", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 syn = { version = "2.0", features = ["full", "visit"] }
-prettyplease = "0.2.32"
-twox-hash = "2.1.0"
+prettyplease = "0.2.33"
+twox-hash = "2.1.1"
 futures = "0.3.31"
 indicatif = "0.17.11"
 console = "0.15.11"
-color-eyre = "0.6.3"
+color-eyre = "0.6.5"
 crossterm = "0.29.0"
 async-trait = "0.1.88"
 log = "0.4.27"
 env_logger = "0.11.8"
-kinetics-parser = { path = "../parser", version = "0.3.1" }
-tabled = "0.19.0"
+kinetics-parser = { path = "../parser", version = "0.3.5" }
+tabled = "0.20.0"
 terminal_size = "0.4.2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kinetics"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 description = "Kinetics is a hosting platform for Rust applications that allows you to deploy all types of workloads by writing **only Rust code**."
 license = "Apache-2.0 OR MIT"
@@ -41,6 +41,6 @@ crossterm = "0.29.0"
 async-trait = "0.1.88"
 log = "0.4.27"
 env_logger = "0.11.8"
-kinetics-parser = { path = "../parser", version = "0.3.5" }
+kinetics-parser = { path = "../parser", version = "0.3.6" }
 tabled = "0.20.0"
 terminal_size = "0.4.2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kinetics"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 description = "Kinetics is a hosting platform for Rust applications that allows you to deploy all types of workloads by writing **only Rust code**."
 license = "Apache-2.0 OR MIT"

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -34,13 +34,20 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Build your serverless functions
-    Build {},
+    Build {
+        /// Comma-separated list of function names to build (if not specified, all functions will be built)
+        #[arg(short, long)]
+        functions: Option<String>,
+    },
 
     /// Deploy your serverless functions to the cloud
     Deploy {
         /// Maximum number of parallel concurrent builds
         #[arg(short, long, default_value_t = 6)]
         max_concurrency: usize,
+
+        #[arg(short, long)]
+        functions: Option<String>,
     },
 
     /// Destroy your serverless functions
@@ -186,7 +193,7 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
         .install()?;
 
     match &cli.command {
-        Some(Commands::Build {}) => {
+        Some(Commands::Build { .. }) => {
             Pipeline::builder()
                 .with_deploy_enabled(false)
                 .set_crat(Crate::from_current_dir()?)
@@ -197,7 +204,9 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
 
             Ok(())
         }
-        Some(Commands::Deploy { max_concurrency }) => {
+        Some(Commands::Deploy {
+            max_concurrency, ..
+        }) => {
             Pipeline::builder()
                 .set_max_concurrent(*max_concurrency)
                 .with_deploy_enabled(true)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -178,13 +178,47 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
 
     let crat = Crate::from_current_dir()?;
 
-    // Functions to deploy
-    let functions: Vec<Function> =
+    // All functions to add to the template
+    let all_functions: Vec<Function> =
         prepare_crates(PathBuf::from(build_config()?.build_path), crat.clone())?
             .into_iter()
             // Avoid building functions supposed for local invocations only
             .filter(|f| !f.is_local().unwrap())
             .collect();
+
+    // Functions to deploy
+    let mut deploy_functions: Vec<Function> = all_functions.clone();
+
+    // Filter functions based on --functions parameter if provided
+    let build_names = if let Some(Commands::Build { functions: names }) = &cli.command {
+        names
+    } else {
+        &None::<String>
+    };
+
+    let deploy_names = if let Some(Commands::Deploy {
+        functions: names, ..
+    }) = &cli.command
+    {
+        names
+    } else {
+        &None::<String>
+    };
+
+    if build_names.is_some() || deploy_names.is_some() {
+        let names: Vec<String> = build_names
+            .clone()
+            .unwrap_or(deploy_names.clone().unwrap_or_default())
+            .split(',')
+            .map(|s| s.trim().into())
+            .collect();
+
+        deploy_functions = all_functions
+            .clone()
+            .into_iter()
+            .filter(|f| names.contains(&f.name.as_str().to_string()))
+            .collect();
+    }
 
     color_eyre::config::HookBuilder::default()
         .display_location_section(false)
@@ -199,7 +233,7 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
                 .set_crat(Crate::from_current_dir()?)
                 .build()
                 .wrap_err("Failed to build pipeline")?
-                .run(functions)
+                .run(all_functions.clone(), deploy_functions.clone())
                 .await?;
 
             Ok(())
@@ -214,7 +248,7 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
                 .set_crat(Crate::from_current_dir()?)
                 .build()
                 .wrap_err("Failed to build pipeline")?
-                .run(functions)
+                .run(all_functions, deploy_functions)
                 .await?;
 
             Ok(())
@@ -233,7 +267,7 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
             table,
         }) => {
             invoke(
-                &Function::find_by_name(&functions, name)?,
+                &Function::find_by_name(&all_functions, name)?,
                 &crat,
                 payload,
                 headers,
@@ -244,11 +278,11 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
             Ok(())
         }
         Some(Commands::Logs { name }) => {
-            logs(&Function::find_by_name(&functions, name)?, &crat).await?;
+            logs(&Function::find_by_name(&all_functions, name)?, &crat).await?;
             Ok(())
         }
         Some(Commands::List { verbose }) => {
-            if functions.is_empty() {
+            if all_functions.is_empty() {
                 println!("{}", console::style("No functions found").yellow());
             } else {
                 list(&crat, *verbose).await?;

--- a/cli/src/crat.rs
+++ b/cli/src/crat.rs
@@ -101,7 +101,7 @@ impl Crate {
 
                 Ok(Self {
                     name: f.name.clone(),
-                    s3key_encrypted: f.s3key_encrypted().ok_or_eyre("No S3 key provided")?,
+                    s3key_encrypted: f.s3key_encrypted().unwrap_or_default(),
                     toml: toml::to_string(&manifest)?,
                 })
             }

--- a/cli/src/crat.rs
+++ b/cli/src/crat.rs
@@ -3,7 +3,7 @@ use crate::deploy::DeployConfig;
 use crate::error::Error;
 use crate::function::Function;
 use crate::secret::Secret;
-use eyre::{ContextCompat, Ok, OptionExt, WrapErr};
+use eyre::{ContextCompat, Ok, WrapErr};
 use reqwest::StatusCode;
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/cli/src/crat.rs
+++ b/cli/src/crat.rs
@@ -77,9 +77,6 @@ impl Crate {
         pub struct BodyFunction {
             pub name: String,
 
-            // Encrypted name of the zip file with the build in S3 bucket
-            pub s3key_encrypted: String,
-
             // Full Cargo.toml
             pub toml: String,
         }
@@ -101,7 +98,6 @@ impl Crate {
 
                 Ok(Self {
                     name: f.name.clone(),
-                    s3key_encrypted: f.s3key_encrypted().unwrap_or_default(),
                     toml: toml::to_string(&manifest)?,
                 })
             }

--- a/cli/src/function.rs
+++ b/cli/src/function.rs
@@ -3,6 +3,7 @@ use crate::client::Client;
 use crate::crat::Crate;
 use crate::deploy::DeployConfig;
 use eyre::{eyre, ContextCompat, OptionExt, WrapErr};
+use serde_json::json;
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -141,6 +142,7 @@ impl Function {
 
         let presigned = client
             .post("/upload")
+            .body(json!({"name": self.name}).to_string())
             .send()
             .await?
             .json::<PreSignedUrl>()

--- a/cli/src/function.rs
+++ b/cli/src/function.rs
@@ -23,7 +23,6 @@ pub enum Type {
 pub struct Function {
     pub id: String,
     pub name: String,
-    pub s3key_encrypted: Option<String>,
 
     // Original parent crate
     pub crat: Crate,
@@ -35,7 +34,6 @@ impl Function {
             id: uuid::Uuid::new_v4().into(),
             name: name.into(),
             crat: Crate::new(path.to_path_buf())?,
-            s3key_encrypted: None,
         })
     }
 
@@ -46,14 +44,6 @@ impl Function {
             .find(|f| name.eq(&f.name))
             .wrap_err("No function with such name")
             .cloned()
-    }
-
-    pub fn set_s3key_encrypted(&mut self, s3key_encrypted: String) {
-        self.s3key_encrypted = Some(s3key_encrypted);
-    }
-
-    pub fn s3key_encrypted(&self) -> Option<String> {
-        self.s3key_encrypted.clone()
     }
 
     fn meta(&self) -> eyre::Result<toml::Value> {
@@ -135,7 +125,6 @@ impl Function {
         #[derive(serde::Deserialize, Debug)]
         struct PreSignedUrl {
             url: String,
-            s3key_encrypted: String,
         }
 
         let path = self.bundle_path();
@@ -157,7 +146,6 @@ impl Function {
             .await?
             .error_for_status()?;
 
-        self.set_s3key_encrypted(presigned.s3key_encrypted);
         Ok(())
     }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 [dependencies]
 aws-config = "1.6.3"
-aws-sdk-dynamodb = "1.77.0"
-aws_lambda_events = "0.16.0"
-lambda_runtime = "0.13.0"
+aws-sdk-dynamodb = "1.79.0"
+aws_lambda_events = "0.16.1"
+lambda_runtime = "0.14.2"
 kinetics-macro = { path = "../macro" }
-lambda_http = "0.14.0"
-tokio = "1.45.0"
-aws-sdk-sqs = "1.70.0"
+lambda_http = "0.15.1"
+tokio = "1.45.1"
+aws-sdk-sqs = "1.72.0"
 serde_json = { version = "1.0.140", features = ["default"] }
 
 [package.metadata.kinetics.kvdb.users]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["parsing"]
 
 [dependencies]
 syn = "2.0.101"
-kinetics-parser = { path = "../parser", version = "0.3.1" }
+kinetics-parser = { path = "../parser", version = "0.3.5" }
 
 [lib]
 proc-macro = true

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kinetics-macro"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 description = "A set of macros used in Kinetics project."
 license = "Apache-2.0 OR MIT"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kinetics-macro"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2021"
 description = "A set of macros used in Kinetics project."
 license = "Apache-2.0 OR MIT"
@@ -10,7 +10,7 @@ categories = ["parsing"]
 
 [dependencies]
 syn = "2.0.101"
-kinetics-parser = { path = "../parser", version = "0.3.6" }
+kinetics-parser = { path = "../parser", version = "0.4.0" }
 
 [lib]
 proc-macro = true

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kinetics-macro"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 description = "A set of macros used in Kinetics project."
 license = "Apache-2.0 OR MIT"
@@ -10,7 +10,7 @@ categories = ["parsing"]
 
 [dependencies]
 syn = "2.0.101"
-kinetics-parser = { path = "../parser", version = "0.3.5" }
+kinetics-parser = { path = "../parser", version = "0.3.6" }
 
 [lib]
 proc-macro = true

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -10,4 +10,4 @@ categories = ["parsing"]
 
 [dependencies]
 syn = { version = "2.0", features = ["full", "visit"] }
-color-eyre = "0.6.4"
+color-eyre = "0.6.5"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kinetics-parser"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 description = "A parser used for Kinetics project."
 license = "Apache-2.0 OR MIT"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kinetics-parser"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 description = "A parser used for Kinetics project."
 license = "Apache-2.0 OR MIT"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kinetics-parser"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2021"
 description = "A parser used for Kinetics project."
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
* Adds `--functions` input param to `build` and  `deploy` commands
* Bundles and uploads only requested functions
* Also deletes the encrypted S3 key param from backend request
  * With hash-based file name generation it's no longer needed.