### PR TITLE
Pipeline stage for prepare crates

### DIFF
--- a/cli/src/build/mod.rs
+++ b/cli/src/build/mod.rs
@@ -85,9 +85,9 @@ pub fn prepare_crates(dst: PathBuf, current_crate: &Crate) -> eyre::Result<Vec<F
             // Fill in necessary data in Cargo.toml
             metadata(&parsed_function, is_local, &mut manifest)?;
             deps(&parsed_function, is_local, &mut manifest)?;
-
-            function_names.push(parsed_function.func_name(is_local));
         }
+
+        function_names.push(parsed_function.func_name(false));
     }
 
     let manifest_string = manifest.to_string();

--- a/cli/src/build/mod.rs
+++ b/cli/src/build/mod.rs
@@ -14,13 +14,13 @@ use std::str::FromStr;
 use walkdir::WalkDir;
 
 /// The entry point to run the command
-pub async fn run(all_functions: &[Function], deploy_functions: &[String]) -> eyre::Result<()> {
+pub async fn run(deploy_functions: &[String]) -> eyre::Result<()> {
     Pipeline::builder()
         .with_deploy_enabled(false)
         .set_crat(Crate::from_current_dir()?)
         .build()
         .wrap_err("Failed to build pipeline")?
-        .run(all_functions, deploy_functions)
+        .run(deploy_functions)
         .await?;
 
     Ok(())
@@ -30,7 +30,7 @@ pub async fn run(all_functions: &[Function], deploy_functions: &[String]) -> eyr
 /// Stores crates inside target_directory and returns list of created paths
 pub fn prepare_crates(dst: PathBuf, current_crate: &Crate) -> eyre::Result<Vec<Function>> {
     // Parse functions from source code
-    let parsed_functions = project_functions(&current_crate)?;
+    let parsed_functions = project_functions(current_crate)?;
 
     let src = &current_crate.path;
     let dst = dst.join(&current_crate.name);

--- a/cli/src/build/mod.rs
+++ b/cli/src/build/mod.rs
@@ -15,16 +15,13 @@ use syn::visit::Visit;
 use walkdir::WalkDir;
 
 /// The entry point to run the command
-pub async fn run(
-    all_functions: Vec<Function>,
-    deploy_functions: Vec<Function>,
-) -> eyre::Result<()> {
+pub async fn run(all_functions: &[Function], deploy_functions: &[String]) -> eyre::Result<()> {
     Pipeline::builder()
         .with_deploy_enabled(false)
         .set_crat(Crate::from_current_dir()?)
         .build()
         .wrap_err("Failed to build pipeline")?
-        .run(all_functions.clone(), deploy_functions.clone())
+        .run(all_functions, deploy_functions)
         .await?;
 
     Ok(())

--- a/cli/src/build/pipeline.rs
+++ b/cli/src/build/pipeline.rs
@@ -145,13 +145,7 @@ impl Pipeline {
 
         let deploy = self
             .crat
-            .deploy(
-                &all_functions
-                    .into_iter()
-                    .filter(|f| !f.is_local().unwrap())
-                    .collect::<Vec<Function>>(),
-                self.deploy_config.as_deref(),
-            )
+            .deploy(&all_functions, self.deploy_config.as_deref())
             .await;
 
         if deploy.is_err() {

--- a/cli/src/build/pipeline.rs
+++ b/cli/src/build/pipeline.rs
@@ -69,12 +69,6 @@ impl Pipeline {
         };
         pipeline_progress.increase_current_function_position();
 
-        let client = if self.is_deploy_enabled {
-            Some(Client::new(self.deploy_config.is_some())?)
-        } else {
-            None
-        };
-
         build(&deploy_functions, &deploying_progress).await?;
         pipeline_progress.increase_current_function_position();
 
@@ -91,6 +85,8 @@ impl Pipeline {
 
             return Ok(());
         }
+
+        let client = Client::new(self.deploy_config.is_some())?;
 
         // Define maximum number of parallel bundling jobs
         let semaphore = Arc::new(Semaphore::new(self.max_concurrent));
@@ -119,7 +115,7 @@ impl Pipeline {
                 function_progress.log_stage("Uploading");
 
                 function
-                    .upload(&client.unwrap(), deploy_config_clone.as_deref())
+                    .upload(&client, deploy_config_clone.as_deref())
                     .await
                     .map_err(|e| {
                         function_progress.error("Uploading");

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -166,11 +166,7 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
 
     // All functions to add to the template
     let all_functions: Vec<Function> =
-        prepare_crates(PathBuf::from(build_config()?.build_path), &crat)?
-            .into_iter()
-            // Avoid building functions supposed for local invocations only
-            .filter(|f| !f.is_local().unwrap())
-            .collect();
+        prepare_crates(PathBuf::from(build_config()?.build_path), &crat)?;
 
     // Functions to deploy
     let mut deploy_functions: Vec<Function> = all_functions.clone();

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 
 /// The entry point to run the command
 pub async fn run(
-    all_functions: Vec<Function>,
-    deploy_functions: Vec<Function>,
+    all_functions: &[Function],
+    deploy_functions: &[String],
     max_concurrency: &usize,
     deploy_config: Option<Arc<dyn DeployConfig>>,
 ) -> eyre::Result<()> {

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 
 /// The entry point to run the command
 pub async fn run(
-    all_functions: &[Function],
     deploy_functions: &[String],
     max_concurrency: &usize,
     deploy_config: Option<Arc<dyn DeployConfig>>,
@@ -20,7 +19,7 @@ pub async fn run(
         .set_crat(Crate::from_current_dir()?)
         .build()
         .wrap_err("Failed to build pipeline")?
-        .run(all_functions, deploy_functions)
+        .run(deploy_functions)
         .await?;
 
     Ok(())

--- a/cli/src/function.rs
+++ b/cli/src/function.rs
@@ -260,7 +260,7 @@ impl Function {
 }
 
 /// Parse current project code
-/// and return all functions encountered with `kinetics` attributes.
+/// and return all functions encountered with `kinetics` macro.
 pub fn project_functions(crat: &Crate) -> eyre::Result<Vec<ParsedFunction>> {
     // Parse functions from source code
     let mut parser = Parser::new();

--- a/cli/src/function.rs
+++ b/cli/src/function.rs
@@ -153,7 +153,7 @@ impl Function {
     }
 
     /// Return true if the function is the only supposed for local invocations
-    pub fn is_local(&self) -> eyre::Result<bool> {
+    pub fn _is_local(&self) -> eyre::Result<bool> {
         if self.meta().is_err() {
             return Err(eyre!("Could not get function's meta {}", self.name,));
         }

--- a/cli/src/invoke/mod.rs
+++ b/cli/src/invoke/mod.rs
@@ -1,12 +1,16 @@
 mod dynamodb;
 mod local;
 mod remote;
+use std::path::PathBuf;
+
+use crate::build::prepare_crates;
+use crate::config::build_config;
 use crate::crat::Crate;
 use crate::function::Function;
 
 /// Invoke the function either locally or remotely
 pub async fn invoke(
-    function: &Function,
+    function_name: &str,
     crat: &Crate,
     payload: &str,
     headers: &str,
@@ -16,10 +20,14 @@ pub async fn invoke(
 
     is_local: bool,
 ) -> eyre::Result<()> {
+    // Get function names as well as pull all updates from the code.
+    let all_functions = prepare_crates(PathBuf::from(build_config()?.build_path), crat)?;
+    let function = Function::find_by_name(&all_functions, function_name)?;
+
     if is_local {
-        local::invoke(function, crat, payload, headers, table).await?;
+        local::invoke(&function, crat, payload, headers, table).await?
     } else {
-        remote::invoke(function, crat, payload, headers).await?;
+        remote::invoke(&function, crat, payload, headers).await?
     }
 
     Ok(())

--- a/cli/src/logs.rs
+++ b/cli/src/logs.rs
@@ -1,7 +1,7 @@
-use crate::client::Client;
 use crate::crat::Crate;
 use crate::error::Error;
 use crate::function::Function;
+use crate::{client::Client, function::project_functions};
 use chrono::{DateTime, Utc};
 use eyre::{Context, Result};
 use serde::Deserialize;
@@ -18,7 +18,14 @@ struct LogsResponse {
 }
 
 /// Retrieves and displays logs for a specific function
-pub async fn logs(function: &Function, crat: &Crate) -> Result<()> {
+pub async fn logs(function_name: &str, crat: &Crate) -> Result<()> {
+    // Get all function names without any additional manupulations.
+    let all_functions = project_functions(crat)?
+        .into_iter()
+        .map(|f| Function::new(&crat.path, &f.func_name(false)))
+        .collect::<eyre::Result<Vec<Function>>>()?;
+    let function = Function::find_by_name(&all_functions, function_name)?;
+
     let client = Client::new(false)?;
 
     println!(


### PR DESCRIPTION
This change moves the universal call to `prepare_crates` into specific command handlers. As a result:
- `build` and `deploy` commands include the prepare stage as an additional step;
- `invoke` command retains full logic of crate preparation and update of the code within `~/.kinetics/<project>` folder;
- `logs` command keeps only the necessary logic related to searching for a function in the project, while avoiding unnecessary code updates.