### PR TITLE
Remove redundant clones from cli and logs

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -145,9 +145,9 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
         }) => {
             return init(
                 name,
-                if cron.to_owned() {
+                if *cron {
                     FunctionType::Cron
-                } else if worker.to_owned() {
+                } else if *worker {
                     FunctionType::Worker
                 } else {
                     FunctionType::Endpoint
@@ -175,13 +175,9 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
             max_concurrency,
             ..
         }) => deploy::run(functions, max_concurrency, deploy_config).await,
-        Some(Commands::Destroy {}) => {
-            destroy(&Crate::from_current_dir()?)
-                .await
-                .wrap_err("Failed to destroy the project")?;
-
-            Ok(())
-        }
+        Some(Commands::Destroy {}) => destroy(&crat)
+            .await
+            .wrap_err("Failed to destroy the project"),
         Some(Commands::Invoke {
             name,
             payload,

--- a/cli/src/logs.rs
+++ b/cli/src/logs.rs
@@ -38,7 +38,7 @@ pub async fn logs(function_name: &str, crat: &Crate) -> Result<()> {
     let response = client
         .post("/function/logs")
         .json(&serde_json::json!({
-            "crate_name": crat.name.clone(),
+            "crate_name": crat.name,
             "function_name": function.name
         }))
         .send()


### PR DESCRIPTION
This way we save a few unnecessary CPU cycles.