### PR TITLE
Tune up CLI progress indication to look more lie cargo

### DIFF
--- a/cli/src/build/pipeline.rs
+++ b/cli/src/build/pipeline.rs
@@ -258,7 +258,7 @@ impl PipelineProgress {
             ProgressStyle::default_bar()
                 .template(
                     format!(
-                        "   {} [{{bar:40}}] {{pos}}/{{len}}",
+                        "   {} [{{bar:30}}] {{pos}}/{{len}} {{wide_msg:.dim}}",
                         console::style(if is_deploy { "Deploying" } else { "Building" })
                             .cyan()
                             .bold()

--- a/cli/src/function.rs
+++ b/cli/src/function.rs
@@ -320,33 +320,12 @@ pub async fn build(
                 continue;
             }
 
-            let trim_to = 48;
-
-            if line.trim().is_empty() {
-                progress
-                    .progress_bar
-                    .set_message(format!("{}", console::style("    Building").green().bold(),));
-            } else {
-                let line = line.trim();
-
-                progress.progress_bar.set_message(format!(
-                    "{} {}...",
-                    console::style("    Building").green().bold(),
-                    console::style(
-                        if line.len() > trim_to {
-                            &line[..std::cmp::min(line.len(), trim_to) - 1]
-                        } else {
-                            line
-                        }
-                        .to_string()
-                    )
-                    .dim()
-                ));
-            }
+            let regex = regex::Regex::new(r"^[\t ]+").unwrap();
+            total_progress.set_message(regex.replace_all(&line, "").to_string());
         }
     }
 
-    progress.progress_bar.finish_and_clear();
+    total_progress.set_message("");
     let status = child.wait().await?;
 
     if !status.success() {


### PR DESCRIPTION
* Moves the build step output closer to the progress bar
  * To make it look more like cargo
* Erase the "Preparing..." message after preparation is done
  * Considering it's not a part of the build pipeline.

cargo:
<img width="589" height="198" alt="image" src="https://github.com/user-attachments/assets/bc5f6319-cbd2-48fe-ae8b-8c0a0219acd1" />

kinetics:
<img width="763" height="191" alt="image" src="https://github.com/user-attachments/assets/309cefd9-196c-4b90-a422-50656140c059" />
