### PR TITLE
Deprecate queue alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ The following attribute macro parameters are available:
 - `concurrency`: Max number of concurrent workers.
 - `fifo`: Set to true to enable FIFO processing.
 - `environment`: Environment variables.
-- `queue_alias`: The alias of the queue to be created for the worker. Will be added in `queues` hash map.
 
 [Example](https://github.com/ottofeller/kinetics/blob/main/examples/src/basic/worker.rs).
 

--- a/cli/src/build/mod.rs
+++ b/cli/src/build/mod.rs
@@ -357,16 +357,11 @@ fn metadata(
         Role::Worker(params) => {
             let mut queue_table = toml_edit::Table::new();
             queue_table["name"] = toml_edit::value(&name);
-            if let Some(queue_alias) = &params.queue_alias {
-                queue_table["alias"] = toml_edit::value(queue_alias);
-            };
             queue_table["concurrency"] = toml_edit::value(params.concurrency as i64);
             queue_table["fifo"] = toml_edit::value(params.fifo);
-
             let mut named_table = toml_edit::Table::new();
             named_table.set_implicit(true); // Don't create an empty queue table
             named_table.insert(&name, queue_table.into());
-
             function_meta.insert("queue", named_table.into());
         }
         Role::Endpoint(params) => {

--- a/cli/src/list.rs
+++ b/cli/src/list.rs
@@ -44,8 +44,6 @@ struct WorkerRow {
     fifo: String,
     #[tabled(rename = "Concurrency")]
     concurrency: String,
-    #[tabled(rename = "Queue Alias")]
-    queue_alias: String,
     #[tabled(rename = "Updated")]
     last_modified: String,
 }
@@ -130,12 +128,7 @@ pub fn display_simple(function: &ParsedFunction, options: &HashMap<&str, String>
         }
 
         Role::Cron(params) => println!("{} {}", "Scheduled".dimmed(), params.schedule.cyan()),
-
-        Role::Worker(params) => {
-            if let Some(queue_alias) = params.queue_alias {
-                println!("{} {}", "Queue".dimmed(), queue_alias.cyan());
-            }
-        }
+        Role::Worker(_) => {}
     }
 }
 
@@ -243,7 +236,6 @@ pub async fn list(current_crate: &Crate, is_verbose: bool) -> eyre::Result<()> {
                     environment: format_environment(&format!("{:?}", params.environment)),
                     fifo: format!("{:?}", params.fifo),
                     concurrency: format!("{:?}", params.concurrency),
-                    queue_alias: format!("{:?}", params.queue_alias.unwrap_or("".to_string())),
                     last_modified,
                 });
             }

--- a/examples/src/basic/worker.rs
+++ b/examples/src/basic/worker.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 /// Always returns the first record as failed to process. It will then be retried.
 /// Test locally with the following command:
 /// kinetics invoke BasicWorkerWorker --payload '{"name": "John"}'
-#[worker(fifo = true, queue_alias = "example")]
+#[worker(fifo = true)]
 pub async fn worker(
     records: Vec<QueueRecord>,
     _secrets: &HashMap<String, String>,

--- a/examples/src/queue.rs
+++ b/examples/src/queue.rs
@@ -6,10 +6,6 @@ use serde_json::json;
 use std::collections::HashMap;
 
 /// Send a message to the queue
-///
-/// Must be processed by worker with #[worker(queue_alias = "example")] macro.
-/// Can't be tested locally, as it requires access to the queue. Deploy with this command:
-/// kinetics deploy
 #[endpoint(url_path = "/queue")]
 pub async fn queue(
     _event: Request,

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -35,7 +35,6 @@ pub fn cron(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// Parameters:
 /// - `name`: override the function name
-/// - `queue_alias`: alias of the queue processed by the worker
 /// - `concurrency`: max number of concurrent workers
 /// - `fifo`: set to true to enable FIFO processing
 /// - `environment`: environment variables

--- a/parser/src/worker.rs
+++ b/parser/src/worker.rs
@@ -7,7 +7,6 @@ use syn::{
 #[derive(Debug, Clone)]
 pub struct Worker {
     pub name: Option<String>,
-    pub queue_alias: Option<String>,
     pub concurrency: i16,
     pub fifo: bool,
     pub environment: Environment,
@@ -17,7 +16,6 @@ impl Default for Worker {
     fn default() -> Self {
         Worker {
             name: None,
-            queue_alias: None,
             concurrency: 1,
             fifo: false,
             environment: Environment::new(),
@@ -36,9 +34,6 @@ impl Parse for Worker {
             match ident.to_string().as_str() {
                 "name" => {
                     worker.name = Some(input.parse::<LitStr>()?.value());
-                }
-                "queue_alias" => {
-                    worker.queue_alias = Some(input.parse::<LitStr>()?.value());
                 }
                 "environment" => {
                     worker.environment = parse_environment(input)?;


### PR DESCRIPTION
The `queue_alias` argument in `worker()` macro is no longer needed. A queue's name is generated from the worker function — https://github.com/ottofeller/kinetics/pull/49.

* Deletes the `queue_alias` processing from the code
* Updates examples
* Cleans up docs.