### PR TITLE
Avoid resource and stack updates on no changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,6 +906,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc-fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9f79df9b0383475ae6df8fcf35d4e29528441706385339daf0fe3f4cce040b"
+dependencies = [
+ "crc",
+ "digest",
+ "libc",
+ "rand",
+ "regex",
+ "rustversion",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,7 +1173,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
  "aws-sdk-sqs",
- "kinetics",
+ "kinetics 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambda_http",
  "lambda_runtime",
  "serde_json",
@@ -1887,6 +1916,50 @@ dependencies = [
  "aws-sdk-dynamodb",
  "aws-sdk-sqs",
  "aws_lambda_events",
+ "base64 0.22.1",
+ "chrono",
+ "clap",
+ "color-eyre",
+ "console",
+ "crc-fast",
+ "crossterm",
+ "env_logger",
+ "eyre",
+ "futures",
+ "indicatif",
+ "kinetics-macro 0.7.11",
+ "kinetics-parser 0.7.11",
+ "lambda_runtime",
+ "log",
+ "prettyplease",
+ "regex",
+ "reqwest",
+ "rust_dotenv",
+ "serde",
+ "serde_json",
+ "syn",
+ "tabled",
+ "terminal_size",
+ "tokio",
+ "toml",
+ "toml_edit 0.23.3",
+ "twox-hash",
+ "uuid",
+ "walkdir",
+ "zip",
+]
+
+[[package]]
+name = "kinetics"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df95bdfc43fc9919718e74c9bac9c48c14e826e008f72a326b72dcc1b8ded62"
+dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-sdk-dynamodb",
+ "aws-sdk-sqs",
+ "aws_lambda_events",
  "chrono",
  "clap",
  "color-eyre",
@@ -1896,8 +1969,8 @@ dependencies = [
  "eyre",
  "futures",
  "indicatif",
- "kinetics-macro",
- "kinetics-parser",
+ "kinetics-macro 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kinetics-parser 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambda_runtime",
  "log",
  "prettyplease",
@@ -1922,13 +1995,34 @@ dependencies = [
 name = "kinetics-macro"
 version = "0.7.11"
 dependencies = [
- "kinetics-parser",
+ "kinetics-parser 0.7.11",
+ "syn",
+]
+
+[[package]]
+name = "kinetics-macro"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd28f0faf53c5eff7604aa477f26baef85b0e9f8c30c2e82f6a3c657488699fd"
+dependencies = [
+ "kinetics-parser 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn",
 ]
 
 [[package]]
 name = "kinetics-parser"
 version = "0.7.11"
+dependencies = [
+ "color-eyre",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "kinetics-parser"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f8082fde0f0396cc1f7514252045062f801434dfd4a247f5eb7a0ab7d3bb3e"
 dependencies = [
  "color-eyre",
  "syn",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,3 +51,5 @@ kinetics-parser = { path = "../parser", version = "0.7.11" }
 tabled = "0.20.0"
 terminal_size = "0.4.2"
 lambda_runtime = "0.14.3"
+crc-fast = "1.4.0"
+base64 = "0.22.1"

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -32,6 +32,6 @@ pub trait DeployConfig: Send + Sync {
         toml_string: String,
         secrets: HashMap<String, String>,
         functions: &[Function],
-    ) -> eyre::Result<()>;
-    async fn upload(&self, function: &mut Function) -> eyre::Result<()>;
+    ) -> eyre::Result<bool>;
+    async fn upload(&self, function: &mut Function) -> eyre::Result<bool>;
 }

--- a/cli/src/function.rs
+++ b/cli/src/function.rs
@@ -93,11 +93,12 @@ impl Function {
     }
 
     /// Call the /upload endpoint to get the presigned URL and upload the file
+    /// Returns a boolean indicating whether the resource has been updated.
     pub async fn upload(
         &mut self,
         client: &Client,
         deploy_config: Option<&dyn DeployConfig>,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<bool> {
         if let Some(config) = deploy_config {
             return config.upload(self).await;
         }
@@ -126,7 +127,7 @@ impl Function {
 
         // If the file has not changed, skip the upload.
         if response.status() == StatusCode::NOT_MODIFIED {
-            return Ok(());
+            return Ok(false);
         }
 
         let text = response.text().await?;
@@ -145,7 +146,7 @@ impl Function {
             .await?
             .error_for_status()?;
 
-        Ok(())
+        Ok(true)
     }
 
     /// Return true if the function is the only supposed for local invocations


### PR DESCRIPTION
- For function upload send resource checksum along with the request, allowing detection of updates.
- Support 304 status from upload and deploy endpoints. This way we detect if no changes were generated by either function upload or stack deploy.
  - With no function changes we skip updating the resource in the stack.
  - With no stack updates we skip creating a new version.