### PR TITLE
Add DSQL cluster support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.3",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -230,7 +230,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.3",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -246,6 +246,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-dsql"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987182f2d778abe2f21b61ea5472e7ee33779f90bc1ce13ed08af98f0902fcbf"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http 0.60.12",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "aws-sdk-dynamodb"
 version = "1.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,7 +279,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.3",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -276,7 +301,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.3",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -298,7 +323,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.3",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -320,7 +345,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.3",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -342,7 +367,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.3",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -363,7 +388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.3",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -387,6 +412,26 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
 ]
 
 [[package]]
@@ -474,7 +519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d57c8b53a72d15c8e190475743acf34e4996685e346a3448dd54ef696fc6e0"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.62.3",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -1144,7 +1189,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
  "aws-sdk-sqs",
- "kinetics",
+ "kinetics 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambda_http",
  "lambda_runtime",
  "serde_json",
@@ -1884,6 +1929,7 @@ version = "0.7.11"
 dependencies = [
  "async-trait",
  "aws-config",
+ "aws-sdk-dsql",
  "aws-sdk-dynamodb",
  "aws-sdk-sqs",
  "aws_lambda_events",
@@ -1896,8 +1942,50 @@ dependencies = [
  "eyre",
  "futures",
  "indicatif",
- "kinetics-macro",
- "kinetics-parser",
+ "kinetics-macro 0.7.11",
+ "kinetics-parser 0.7.11",
+ "lambda_runtime",
+ "log",
+ "prettyplease",
+ "regex",
+ "reqwest",
+ "rust_dotenv",
+ "serde",
+ "serde_json",
+ "syn",
+ "tabled",
+ "terminal_size",
+ "tokio",
+ "toml",
+ "toml_edit 0.23.3",
+ "twox-hash",
+ "uuid",
+ "walkdir",
+ "zip",
+]
+
+[[package]]
+name = "kinetics"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df95bdfc43fc9919718e74c9bac9c48c14e826e008f72a326b72dcc1b8ded62"
+dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-sdk-dynamodb",
+ "aws-sdk-sqs",
+ "aws_lambda_events",
+ "chrono",
+ "clap",
+ "color-eyre",
+ "console",
+ "crossterm",
+ "env_logger",
+ "eyre",
+ "futures",
+ "indicatif",
+ "kinetics-macro 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kinetics-parser 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambda_runtime",
  "log",
  "prettyplease",
@@ -1922,13 +2010,34 @@ dependencies = [
 name = "kinetics-macro"
 version = "0.7.11"
 dependencies = [
- "kinetics-parser",
+ "kinetics-parser 0.7.11",
+ "syn",
+]
+
+[[package]]
+name = "kinetics-macro"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd28f0faf53c5eff7604aa477f26baef85b0e9f8c30c2e82f6a3c657488699fd"
+dependencies = [
+ "kinetics-parser 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn",
 ]
 
 [[package]]
 name = "kinetics-parser"
 version = "0.7.11"
+dependencies = [
+ "color-eyre",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "kinetics-parser"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f8082fde0f0396cc1f7514252045062f801434dfd4a247f5eb7a0ab7d3bb3e"
 dependencies = [
  "color-eyre",
  "syn",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 aws-config = "1.8.3"
 aws-sdk-dynamodb = "1.86.0"
 aws-sdk-sqs = "=1.80.0"
+aws-sdk-dsql = "=1.8.0"
 aws_lambda_events = "0.17.0"
 chrono = { version = "0.4.41", features = ["serde"] }
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/cli/src/build/templates/cron.rs
+++ b/cli/src/build/templates/cron.rs
@@ -3,8 +3,11 @@ pub fn cron(import_statement: &str, rust_function_name: &str, is_local: bool) ->
     if is_local {
         format!(
             "{import_statement}
+            use kinetics::tools::KineticsConfig;
             #[tokio::main]\n\
             async fn main() -> Result<(), Box<dyn std::error::Error>> {{\n\
+                let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+                let kinetics_config = KineticsConfig::new(&config).await?;
                 let mut secrets = std::collections::HashMap::new();
 
                 for (k, v) in std::env::vars() {{
@@ -21,6 +24,7 @@ pub fn cron(import_statement: &str, rust_function_name: &str, is_local: bool) ->
     } else {
         format!(
             "{import_statement}
+            use kinetics::tools::KineticsConfig;
             use lambda_runtime::{{LambdaEvent, Error, run, service_fn}};\n\
             use aws_lambda_events::eventbridge::EventBridgeEvent;\n\
             #[tokio::main]\n\
@@ -63,10 +67,11 @@ pub fn cron(import_statement: &str, rust_function_name: &str, is_local: bool) ->
                     secrets.insert(name.into(), secret_value.to_string());
                 }}
 
+                let kinetics_config = KineticsConfig::new(&config).await?;
                 println!(\"Serving requests\");
 
                 run(service_fn(|_event: LambdaEvent<EventBridgeEvent<serde_json::Value>>| async {{
-                    match {rust_function_name}(&secrets).await {{
+                    match {rust_function_name}(&secrets, &kinetics_config).await {{
                         Ok(()) => Ok(()),
                         Err(err) => {{
                             eprintln!(\"Error occurred while handling request: {{:?}}\", err);

--- a/cli/src/tools/config.rs
+++ b/cli/src/tools/config.rs
@@ -1,0 +1,30 @@
+use crate::tools::database::Database;
+use aws_config::SdkConfig;
+use lambda_runtime::Error;
+use std::collections::HashMap;
+
+/// Runtime lambda configuration
+///
+/// Config is passed into the Lambda handler
+#[derive(Clone, Debug)]
+pub struct KineticsConfig {
+    pub db: HashMap<String, Database>,
+}
+
+impl KineticsConfig {
+    pub async fn new(config: &SdkConfig) -> Result<Self, Error> {
+        let mut all_db = HashMap::new();
+
+        for (key, cluster_id) in std::env::vars() {
+            if !key.starts_with("KINETICS_DATABASE_") {
+                continue;
+            }
+
+            let db_name = key.replace("KINETICS_DATABASE_", "");
+            let db = Database::new(&cluster_id, config).await?;
+            all_db.insert(db_name, db);
+        }
+
+        Ok(Self { db: all_db })
+    }
+}

--- a/cli/src/tools/database.rs
+++ b/cli/src/tools/database.rs
@@ -1,0 +1,114 @@
+use aws_config::{Region, SdkConfig};
+use aws_sdk_dsql::auth_token::{AuthToken, AuthTokenGenerator, Config as DsqlConfig};
+use lambda_runtime::Error;
+use log::error;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+#[derive(Clone, Debug)]
+pub struct Database {
+    // Unique identifier for the DSQL cluster
+    cluster_id: String,
+
+    /// Password for DSQL cluster access
+    password: Arc<RwLock<AuthToken>>,
+
+    /// AWS SDK configuration
+    config: SdkConfig,
+}
+
+impl Database {
+    pub async fn new(cluster_id: &str, config: &SdkConfig) -> Result<Self, Error> {
+        let password = fetch_dsql_password(cluster_id, config).await?;
+
+        let database = Self {
+            cluster_id: cluster_id.to_string(),
+            password: Arc::new(RwLock::new(password)),
+            config: config.clone(),
+        };
+
+        // Refresh the auth token in the background
+        database.start_token_refresh();
+
+        Ok(database)
+    }
+
+    pub fn endpoint(&self) -> String {
+        generate_cluster_endpoint(&self.cluster_id, &self.config)
+    }
+
+    pub fn username(&self) -> String {
+        "admin".to_string()
+    }
+
+    pub fn password(&self) -> String {
+        self.password.read().unwrap().to_string()
+    }
+
+    pub fn port(&self) -> u16 {
+        5432
+    }
+
+    pub fn database(&self) -> String {
+        "postgres".to_string()
+    }
+
+    pub fn connection_string(&self) -> String {
+        format!(
+            "postgresql://{username}:{password}@{endpoint}:{port}/{database}",
+            username = self.username(),
+            password = self.password(),
+            endpoint = self.endpoint(),
+            port = self.port(),
+            database = self.database(),
+        )
+    }
+
+    fn start_token_refresh(&self) {
+        let config = self.config.clone();
+        let cluster_id = self.cluster_id.clone();
+        let password = self.password.clone();
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60 * 10));
+            interval.tick().await; // The first tick happens immediately, skip it
+
+            // Exponential backoff state (retry-until-success)
+            let mut backoff = Duration::from_secs(1);
+            let max_backoff = Duration::from_secs(60);
+
+            loop {
+                interval.tick().await;
+
+                match fetch_dsql_password(&cluster_id, &config).await {
+                    Ok(token) => {
+                        *password.write().unwrap() = token;
+                    }
+
+                    Err(err) => {
+                        error!("Failed to refresh auth token: {err}");
+
+                        // Retry-until-success with bounded exponential backoff
+                        tokio::time::sleep(backoff).await;
+                        backoff = std::cmp::min(backoff.saturating_mul(2), max_backoff);
+
+                        // Schedule the next attempt immediately
+                        interval.reset_immediately()
+                    }
+                }
+            }
+        });
+    }
+}
+
+fn generate_cluster_endpoint(cluster_id: &str, config: &SdkConfig) -> String {
+    let region = config.region().unwrap_or(&Region::new("us-east-1")).clone();
+    // See https://docs.aws.amazon.com/general/latest/gr/dsql.html
+    format!("{}.dsql.{}.on.aws", cluster_id, region.as_ref())
+}
+
+async fn fetch_dsql_password(cluster_id: &str, config: &SdkConfig) -> Result<AuthToken, Error> {
+    let endpoint = generate_cluster_endpoint(cluster_id, config);
+    let signer = AuthTokenGenerator::new(DsqlConfig::builder().hostname(endpoint).build()?);
+    signer.db_connect_admin_auth_token(config).await
+}

--- a/cli/src/tools/mod.rs
+++ b/cli/src/tools/mod.rs
@@ -1,1 +1,4 @@
+pub mod config;
+pub mod database;
 pub mod queue;
+pub use config::*;


### PR DESCRIPTION
Add DSQL support for endpoint, worker and cron functions

To use the new feature:

1. Add database section into `Cargo.toml`
```toml
[package.metadata.kinetics.database.kinetics]
name = "some-db-name"
```

2. Deploy your app

3. Use it in your handler
```rs
#[endpoint(url_path = "some-ur")]
pub async fn logs(
    event: Request,
    _secrets: &HashMap<String, String>,
    config: &KineticsConfig,
) -> Result<Response<Body>, Error> {
  let db = config.db.get("some-db-name").ok_or("Failed to get database config")?;

  // Get connection params
  let _ = db.endpoint();
  let _ = db.database();
  let _ = db.password();
  let _ = db.username();
  let _ = db.port();

  // or get connection string
  let _ = db.connection_string();
}
```
