### PR TITLE
Limit function name to 64 chars

### DIFF
--- a/cli/src/build/mod.rs
+++ b/cli/src/build/mod.rs
@@ -90,7 +90,7 @@ pub fn prepare_crates(
     parsed_functions
         .into_iter()
         .map(|f| {
-            let name = f.func_name(false);
+            let name = f.func_name(false)?;
             Function::new(&dst, &name).map(|f| {
                 f.is_deploying(deploy_functions.is_empty() || deploy_functions.contains(&name))
             })
@@ -288,7 +288,7 @@ fn create_lambda_bin(
     manifest: &mut toml_edit::DocumentMut,
     checksum: &mut FileHash,
 ) -> eyre::Result<()> {
-    let function_name = parsed_function.func_name(is_local);
+    let function_name = parsed_function.func_name(is_local)?;
     let lambda_path_local = bin_dir.join(format!("{}.rs", function_name));
     let lambda_path = dst.join(&lambda_path_local);
 
@@ -343,7 +343,7 @@ fn metadata(
         Role::Worker(_) => "worker",
     };
 
-    let name = parsed_function.func_name(is_local);
+    let name = parsed_function.func_name(is_local)?;
 
     // Create a function table for both roles
     let mut function_table = toml_edit::Table::new();

--- a/cli/src/list.rs
+++ b/cli/src/list.rs
@@ -120,6 +120,8 @@ pub fn display_simple(function: &ParsedFunction, project_base_url: &str) -> eyre
         Role::Cron(params) => println!("{} {}", "Scheduled".dimmed(), params.schedule.cyan()),
         Role::Worker(_) => {}
     }
+
+    println!();
     Ok(())
 }
 
@@ -144,7 +146,7 @@ fn simple(functions: &[ParsedFunction], project_base_url: &str) -> eyre::Result<
 
         endpoints
             .iter()
-            .try_for_each(|f| display_simple(f, project_base_url).inspect(|_| println!()))?;
+            .try_for_each(|f| display_simple(f, project_base_url))?;
     }
 
     if !workers.is_empty() {
@@ -152,7 +154,7 @@ fn simple(functions: &[ParsedFunction], project_base_url: &str) -> eyre::Result<
 
         workers
             .iter()
-            .try_for_each(|f| display_simple(f, project_base_url).inspect(|_| println!()))?;
+            .try_for_each(|f| display_simple(f, project_base_url))?;
     }
 
     if !crons.is_empty() {
@@ -160,7 +162,7 @@ fn simple(functions: &[ParsedFunction], project_base_url: &str) -> eyre::Result<
 
         crons
             .iter()
-            .try_for_each(|f| display_simple(f, project_base_url).inspect(|_| println!()))?;
+            .try_for_each(|f| display_simple(f, project_base_url))?;
     }
 
     Ok(())

--- a/cli/src/logs.rs
+++ b/cli/src/logs.rs
@@ -24,7 +24,7 @@ pub async fn logs(function_name: &str, crat: &Crate) -> Result<()> {
     let all_functions = Parser::new(Some(&crat.path))?
         .functions
         .into_iter()
-        .map(|f| Function::new(&crat.path, &f.func_name(false)))
+        .map(|f| Function::new(&crat.path, &f.func_name(false)?))
         .collect::<eyre::Result<Vec<Function>>>()?;
     let function = Function::find_by_name(&all_functions, function_name)?;
 

--- a/cli/src/stats.rs
+++ b/cli/src/stats.rs
@@ -43,7 +43,7 @@ pub async fn stats(function_name: &str, crat: &Crate, period: u32) -> Result<()>
     let all_functions = Parser::new(Some(&crat.path))?
         .functions
         .into_iter()
-        .map(|f| Function::new(&crat.path, &f.func_name(false)))
+        .map(|f| Function::new(&crat.path, &f.func_name(false)?))
         .collect::<eyre::Result<Vec<Function>>>()?;
     let function = Function::find_by_name(&all_functions, function_name)?;
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -39,17 +39,18 @@ impl ParsedFunction {
     /// By default use the Rust function plus crate path as the function name. Convert
     /// some-name to SomeName, and do other transformations in order to comply with Lambda
     /// function name requirements.
-    pub fn func_name(&self, is_local: bool) -> String {
+    pub fn func_name(&self, is_local: bool) -> eyre::Result<String> {
         let rust_name = &self.rust_function_name;
         let full_path = format!("{}/{rust_name}", self.relative_path);
         let default_func_name = Self::escape_path(&full_path);
+        let name = self.role.name().unwrap_or(&default_func_name);
 
-        // TODO Check the name for uniqueness
-        format!(
-            "{}{}",
-            self.role.name().unwrap_or(&default_func_name),
-            if is_local { "Local" } else { "" }
-        )
+        if name.len() > 64 {
+            Err(eyre::eyre!("Too long function name: {}", name))
+        } else {
+            // TODO Check the name for uniqueness
+            Ok(format!("{}{}", name, if is_local { "Local" } else { "" }))
+        }
     }
 }
 


### PR DESCRIPTION
This way we guard against backend resource name restrictions, before calling any endpoint.