### PR TITLE
Create internal body type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,12 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,9 +152,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.5"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478f5b10ce55c9a33f87ca3404ca92768b144fc1bfdede7c0121214a8283a25"
+checksum = "8bc1b40fb26027769f16960d2f4a6bc20c4bb755d403e552c8c1a73af433c246"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -188,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.5"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1541072f81945fa1251f8795ef6c92c4282d74d59f88498ae7d4bf00f0ebdad9"
+checksum = "d025db5d9f52cbc413b167136afb3d8aeea708c0d8884783cf6253be5e22f6f2"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -247,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.91.0"
+version = "1.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b548fe38d7538b6ed26171e858770336d038ba36314db9c6dda6e033fc49d8"
+checksum = "0c1d9a7084cc5b14acae411d19f33a693fdb06ac55044705deb88844c8b58aa9"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -291,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.82.0"
+version = "1.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b069e4973dc25875bbd54e4c6658bdb4086a846ee9ed50f328d4d4c33ebf9857"
+checksum = "643cd43af212d2a1c4dedff6f044d7e1961e5d9e7cfe773d70f31d9842413886"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -313,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.83.0"
+version = "1.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b49e8fe57ff100a2f717abfa65bdd94e39702fa5ab3f60cddc6ac7784010c68"
+checksum = "20ec4a95bd48e0db7a424356a161f8d87bd6a4f0af37204775f0da03d9e39fc3"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -335,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.84.0"
+version = "1.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91abcdbfb48c38a0419eb75e0eac772a4783a96750392680e4f3c25a8a0535b9"
+checksum = "410309ad0df4606bc721aff0d89c3407682845453247213a0ccc5ff8801ee107"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -578,6 +572,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws_lambda_events"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831de96bc2c9d2e570664f4f016c8d56d86ce2a58b3a1d6268c4ba2f269684fe"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "flate2",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-serde",
+ "query_map",
+ "serde",
+ "serde_dynamo",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "block-buffer"
@@ -694,10 +708,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -726,17 +741,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -762,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -772,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -784,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -844,15 +858,15 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "console"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -922,9 +936,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc-fast"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9f79df9b0383475ae6df8fcf35d4e29528441706385339daf0fe3f4cce040b"
+checksum = "61dd931a9d071dc6e36b8735c501601428c5aa5dfd6d2506b935498ef57e0098"
 dependencies = [
  "crc",
  "digest",
@@ -1023,9 +1037,9 @@ checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1173,11 +1187,12 @@ dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
  "aws-sdk-sqs",
- "kinetics 0.7.11",
- "lambda_http",
+ "http 1.3.1",
+ "kinetics 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambda_runtime",
  "serde_json",
  "tokio",
+ "tower",
 ]
 
 [[package]]
@@ -1195,6 +1210,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "flate2"
@@ -1350,7 +1371,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.4+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1899,54 +1920,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "kinetics"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df95bdfc43fc9919718e74c9bac9c48c14e826e008f72a326b72dcc1b8ded62"
-dependencies = [
- "async-trait",
- "aws-config",
- "aws-sdk-dynamodb",
- "aws-sdk-sqs",
- "aws_lambda_events",
- "chrono",
- "clap",
- "color-eyre",
- "console",
- "crossterm",
- "env_logger",
- "eyre",
- "futures",
- "indicatif",
- "kinetics-macro 0.7.11",
- "kinetics-parser 0.7.11",
- "lambda_runtime",
- "log",
- "prettyplease",
- "regex",
- "reqwest",
- "rust_dotenv",
- "serde",
- "serde_json",
- "syn",
- "tabled",
- "terminal_size",
- "tokio",
- "toml",
- "toml_edit 0.23.4",
- "twox-hash",
- "uuid",
- "walkdir",
- "zip",
 ]
 
 [[package]]
@@ -1957,7 +1936,57 @@ dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
  "aws-sdk-sqs",
- "aws_lambda_events",
+ "aws_lambda_events 0.18.0",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "clap",
+ "color-eyre",
+ "console",
+ "crc-fast",
+ "crossterm",
+ "env_logger",
+ "eyre",
+ "futures",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "indicatif",
+ "kinetics-macro 0.7.13",
+ "kinetics-parser 0.7.13",
+ "lambda_http",
+ "lambda_runtime",
+ "log",
+ "prettyplease",
+ "regex",
+ "reqwest",
+ "rust_dotenv",
+ "serde",
+ "serde_json",
+ "sha256",
+ "syn",
+ "tabled",
+ "terminal_size",
+ "tokio",
+ "toml",
+ "toml_edit 0.23.4",
+ "tower",
+ "twox-hash",
+ "uuid",
+ "walkdir",
+ "zip",
+]
+
+[[package]]
+name = "kinetics"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca7886b83c1eb64ce824f9401c178a6122a2c1614d8a9b7c6d75cdba7eece15a"
+dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-sdk-dynamodb",
+ "aws-sdk-sqs",
+ "aws_lambda_events 0.17.0",
  "base64 0.22.1",
  "chrono",
  "clap",
@@ -1969,8 +1998,8 @@ dependencies = [
  "eyre",
  "futures",
  "indicatif",
- "kinetics-macro 0.7.13",
- "kinetics-parser 0.7.13",
+ "kinetics-macro 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kinetics-parser 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambda_runtime",
  "log",
  "prettyplease",
@@ -1994,16 +2023,6 @@ dependencies = [
 
 [[package]]
 name = "kinetics-macro"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28f0faf53c5eff7604aa477f26baef85b0e9f8c30c2e82f6a3c657488699fd"
-dependencies = [
- "kinetics-parser 0.7.11",
- "syn",
-]
-
-[[package]]
-name = "kinetics-macro"
 version = "0.7.13"
 dependencies = [
  "kinetics-parser 0.7.13",
@@ -2011,10 +2030,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "kinetics-parser"
-version = "0.7.11"
+name = "kinetics-macro"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f8082fde0f0396cc1f7514252045062f801434dfd4a247f5eb7a0ab7d3bb3e"
+checksum = "fc351e779640a1c77b08f6aa02c7112356fe43e161ca0b3d53947bfe68376608"
+dependencies = [
+ "kinetics-parser 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn",
+]
+
+[[package]]
+name = "kinetics-parser"
+version = "0.7.13"
 dependencies = [
  "color-eyre",
  "syn",
@@ -2024,6 +2051,8 @@ dependencies = [
 [[package]]
 name = "kinetics-parser"
 version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a1554bd19e60405cc197aa4d781801a1b6407a8ef03490d792bb8500eb16e84"
 dependencies = [
  "color-eyre",
  "syn",
@@ -2032,11 +2061,11 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae130903c5ecaf238bb2e08c22d678e330d72aefc1f503bd02a18f4fcc5e8e12"
+checksum = "c11fef0236dc427a2968c701697ae2ed3353cd6936be4d4f9ab471b0d6cf753b"
 dependencies = [
- "aws_lambda_events",
+ "aws_lambda_events 0.18.0",
  "bytes",
  "encoding_rs",
  "futures-util",
@@ -2155,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
 dependencies = [
  "zlib-rs",
 ]
@@ -2198,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru-slab"
@@ -2210,11 +2239,11 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2650,17 +2679,8 @@ checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.10",
- "regex-syntax 0.8.6",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2671,7 +2691,7 @@ checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.6",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2679,12 +2699,6 @@ name = "regex-lite"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943f41321c63ef1c92fd763bfe054d2668f7f225a5c29f0105903dc2fc04ba30"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2853,7 +2867,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.3.0",
+ "security-framework 3.4.0",
 ]
 
 [[package]]
@@ -2982,9 +2996,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",
@@ -2995,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3355,12 +3369,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -3370,15 +3383,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3662,13 +3675,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -3686,9 +3699,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
  "rand",
 ]
@@ -3761,9 +3774,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -3815,30 +3828,31 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.4+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -3850,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3863,9 +3877,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3873,9 +3887,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3886,18 +3900,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3952,11 +3966,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3973,7 +3987,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -4007,12 +4021,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4021,7 +4041,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4052,6 +4072,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4073,7 +4102,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -4191,9 +4220,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "writeable"
@@ -4233,18 +4262,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4327,9 +4356,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.5.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835eb39822904d39cb19465de1159e05d371973f0c6df3a365ad50565ddc8b9"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "aes",
  "arbitrary",
@@ -4354,9 +4383,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
 
 [[package]]
 name = "zopfli"
@@ -4390,9 +4419,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Kinetics is a hosting platform for Rust applications that allows deploying all t
     environment = {"SOME_VAR": "SomeVal"},
 )]
 pub async fn endpoint(
-    _event: Request,
+    _event: Request<()>,
     _secrets: &HashMap<String, String>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<Body>, BoxError> {
     let resp = Response::builder()
         .status(200)
         .header("content-type", "text/html")

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 aws-config = "1.8.3"
 aws-sdk-dynamodb = "1.86.0"
 aws-sdk-sqs = "=1.80.0"
-aws_lambda_events = "0.17.0"
+aws_lambda_events = "^0"
 chrono = { version = "0.4.41", features = ["serde"] }
 uuid = { version = "1.17.0", features = ["v4"] }
 clap = { version = "4.5.42", features = ["derive"] }
@@ -58,3 +58,8 @@ lambda_runtime = "0.14.3"
 crc-fast = "1.4.0"
 base64 = "0.22.1"
 sha256 = "1.6.0"
+bytes = "^1.0"
+http = "^1.0"
+http-body = "^1.0"
+lambda_http = "^0"
+tower = "^0"

--- a/cli/src/build/mod.rs
+++ b/cli/src/build/mod.rs
@@ -443,13 +443,13 @@ fn deps(
             doc["dependencies"]["lambda_runtime"]
                 .or_insert(toml_edit::Table::new().into())
                 .as_table_mut()
-                .map(|t| t.insert("version", toml_edit::value("0.13.0")));
+                .map(|t| t.insert("version", toml_edit::value("^0.14")));
         }
         Role::Endpoint(_) => {
             doc["dependencies"]["lambda_http"]
                 .or_insert(toml_edit::Table::new().into())
                 .as_table_mut()
-                .map(|t| t.insert("version", toml_edit::value("0.14.0")));
+                .map(|t| t.insert("version", toml_edit::value("^0")));
         }
     };
 
@@ -461,7 +461,7 @@ fn deps(
     doc["dependencies"]["aws_lambda_events"]
         .or_insert(toml_edit::Table::new().into())
         .as_table_mut()
-        .map(|t| t.insert("version", toml_edit::value("0.16.0")));
+        .map(|t| t.insert("version", toml_edit::value("^0")));
 
     doc["dependencies"]["aws-config"]
         .or_insert(toml_edit::Table::new().into())

--- a/cli/src/build/mod.rs
+++ b/cli/src/build/mod.rs
@@ -450,6 +450,14 @@ fn deps(
                 .or_insert(toml_edit::Table::new().into())
                 .as_table_mut()
                 .map(|t| t.insert("version", toml_edit::value("^0")));
+            doc["dependencies"]["http"]
+                .or_insert(toml_edit::Table::new().into())
+                .as_table_mut()
+                .map(|t| t.insert("version", toml_edit::value("^1.0")));
+            doc["dependencies"]["tower"]
+                .or_insert(toml_edit::Table::new().into())
+                .as_table_mut()
+                .map(|t| t.insert("version", toml_edit::value("^0")));
         }
     };
 

--- a/cli/src/tools/http.rs
+++ b/cli/src/tools/http.rs
@@ -77,11 +77,10 @@ impl From<lambda_http::Body> for Body {
 impl TryFrom<Body> for () {
     type Error = eyre::Error;
 
-    fn try_from(value: Body) -> Result<Self, Self::Error> {
-        match value {
-            Body::Empty => Ok(()),
-            _ => Err(eyre::eyre!("Body not empty")),
-        }
+    fn try_from(_value: Body) -> Result<Self, Self::Error> {
+        // Unit struct usually implies no payload,
+        // thus we just htrow the body away.
+        Ok(())
     }
 }
 

--- a/cli/src/tools/http.rs
+++ b/cli/src/tools/http.rs
@@ -1,0 +1,139 @@
+use http_body::{Body as HttpBody, Frame, SizeHint};
+use std::{borrow::Cow, mem::take, pin::Pin, task::Poll};
+
+/// Request body supported by kinetics runtime.
+/// In addition to empty bodies string and binary data are supported.
+#[derive(Debug, Default, Eq, PartialEq)]
+pub enum Body {
+    /// An empty body
+    #[default]
+    Empty,
+    /// A body containing string data
+    Text(String),
+    /// A body containing binary data
+    Binary(Vec<u8>),
+}
+
+impl From<()> for Body {
+    fn from(_: ()) -> Self {
+        Body::Empty
+    }
+}
+
+impl<'a> From<&'a str> for Body {
+    fn from(s: &'a str) -> Self {
+        Body::Text(s.into())
+    }
+}
+
+impl From<String> for Body {
+    fn from(b: String) -> Self {
+        Body::Text(b)
+    }
+}
+
+impl From<Cow<'static, str>> for Body {
+    #[inline]
+    fn from(cow: Cow<'static, str>) -> Body {
+        match cow {
+            Cow::Borrowed(b) => Body::from(b.to_owned()),
+            Cow::Owned(o) => Body::from(o),
+        }
+    }
+}
+
+impl From<Cow<'static, [u8]>> for Body {
+    #[inline]
+    fn from(cow: Cow<'static, [u8]>) -> Body {
+        match cow {
+            Cow::Borrowed(b) => Body::from(b),
+            Cow::Owned(o) => Body::from(o),
+        }
+    }
+}
+
+impl From<Vec<u8>> for Body {
+    fn from(b: Vec<u8>) -> Self {
+        Body::Binary(b)
+    }
+}
+
+impl<'a> From<&'a [u8]> for Body {
+    fn from(b: &'a [u8]) -> Self {
+        Body::Binary(b.to_vec())
+    }
+}
+
+impl From<lambda_http::Body> for Body {
+    fn from(value: lambda_http::Body) -> Self {
+        match value {
+            lambda_http::Body::Empty => Body::Empty,
+            lambda_http::Body::Text(chars) => Body::Text(chars),
+            lambda_http::Body::Binary(bytes) => Body::Binary(bytes),
+        }
+    }
+}
+
+impl TryFrom<Body> for () {
+    type Error = eyre::Error;
+
+    fn try_from(value: Body) -> Result<Self, Self::Error> {
+        match value {
+            Body::Empty => Ok(()),
+            _ => Err(eyre::eyre!("Body not empty")),
+        }
+    }
+}
+
+impl TryFrom<Body> for String {
+    type Error = eyre::Error;
+
+    fn try_from(value: Body) -> Result<Self, Self::Error> {
+        match value {
+            Body::Empty => Ok(String::new()),
+            Body::Text(chars) => Ok(chars),
+            Body::Binary(bytes) => Ok(String::try_from(bytes)?),
+        }
+    }
+}
+
+impl TryFrom<Body> for Vec<u8> {
+    type Error = eyre::Error;
+
+    fn try_from(value: Body) -> Result<Self, Self::Error> {
+        match value {
+            Body::Empty => Ok(Vec::new()),
+            Body::Text(chars) => Ok(chars.into_bytes()),
+            Body::Binary(bytes) => Ok(bytes),
+        }
+    }
+}
+
+impl HttpBody for Body {
+    type Data = bytes::Bytes;
+    type Error = tower::BoxError;
+
+    fn is_end_stream(&self) -> bool {
+        matches!(self, Body::Empty)
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        match self {
+            Body::Empty => SizeHint::default(),
+            Body::Text(ref s) => SizeHint::with_exact(s.len() as u64),
+            Body::Binary(ref b) => SizeHint::with_exact(b.len() as u64),
+        }
+    }
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let body = take(self.get_mut());
+        Poll::Ready(match body {
+            Body::Empty => None,
+            Body::Text(s) => Some(Ok(Frame::data(s.into()))),
+            Body::Binary(b) => Some(Ok(Frame::data(b.into()))),
+        })
+    }
+}

--- a/cli/src/tools/http.rs
+++ b/cli/src/tools/http.rs
@@ -108,6 +108,18 @@ impl TryFrom<Body> for Vec<u8> {
     }
 }
 
+impl TryFrom<Body> for lambda_http::Body {
+    type Error = eyre::Error;
+
+    fn try_from(value: Body) -> Result<Self, Self::Error> {
+        match value {
+            Body::Empty => Ok(lambda_http::Body::Empty),
+            Body::Text(chars) => Ok(lambda_http::Body::Text(chars)),
+            Body::Binary(bytes) => Ok(lambda_http::Body::Binary(bytes)),
+        }
+    }
+}
+
 impl HttpBody for Body {
     type Data = bytes::Bytes;
     type Error = tower::BoxError;

--- a/cli/src/tools/mod.rs
+++ b/cli/src/tools/mod.rs
@@ -1,3 +1,4 @@
+pub mod http;
 pub mod queue;
 
 /// Unique resource name

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,9 +9,10 @@ name = "mytable"
 [dependencies]
 aws-config = "1.8.3"
 aws-sdk-dynamodb = "1.86.0"
+http = "^1.0"
 lambda_runtime = "0.14.3"
-kinetics = "0.7.11"
-lambda_http = "0.16.0"
+kinetics = { version = "0.7.13" }
 tokio = "1.47.1"
+tower = "^0"
 aws-sdk-sqs = "1.78.0"
 serde_json = { version = "1.0.142", features = ["default"] }

--- a/examples/src/basic/endpoint.rs
+++ b/examples/src/basic/endpoint.rs
@@ -1,5 +1,5 @@
 use http::{Request, Response};
-use kinetics::macros::endpoint;
+use kinetics::{macros::endpoint, tools::http::Body};
 use serde_json::json;
 use std::collections::HashMap;
 use tower::BoxError;
@@ -10,7 +10,7 @@ use tower::BoxError;
 /// kinetics invoke BasicEndpointEndpoint
 #[endpoint(url_path = "/endpoint")]
 pub async fn endpoint(
-    _event: Request<String>,
+    _event: Request<Body>,
     _secrets: &HashMap<String, String>,
 ) -> Result<Response<String>, BoxError> {
     let resp = Response::builder()

--- a/examples/src/basic/endpoint.rs
+++ b/examples/src/basic/endpoint.rs
@@ -1,7 +1,8 @@
+use http::{Request, Response};
 use kinetics::macros::endpoint;
-use lambda_http::{Body, Error, Request, Response};
 use serde_json::json;
 use std::collections::HashMap;
+use tower::BoxError;
 
 /// REST API endpoint which responds with JSON {"success": true}
 ///
@@ -9,14 +10,13 @@ use std::collections::HashMap;
 /// kinetics invoke BasicEndpointEndpoint
 #[endpoint(url_path = "/endpoint")]
 pub async fn endpoint(
-    _event: Request,
+    _event: Request<String>,
     _secrets: &HashMap<String, String>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<String>, BoxError> {
     let resp = Response::builder()
         .status(200)
         .header("content-type", "application/json")
-        .body(json!({"success": true}).to_string().into())
-        .map_err(Box::new)?;
+        .body(json!({"success": true}).to_string())?;
 
     Ok(resp)
 }

--- a/examples/src/basic/endpoint.rs
+++ b/examples/src/basic/endpoint.rs
@@ -2,6 +2,8 @@ use http::{Request, Response};
 use kinetics::{macros::endpoint, tools::http::Body};
 use serde_json::json;
 use std::collections::HashMap;
+// As an example use a general-purpose type-erased error from tower.
+// Custom errors would work as well.
 use tower::BoxError;
 
 /// REST API endpoint which responds with JSON {"success": true}

--- a/examples/src/basic/worker.rs
+++ b/examples/src/basic/worker.rs
@@ -1,7 +1,7 @@
 use kinetics::macros::worker;
 use kinetics::tools::queue::{Record as QueueRecord, Retries as QueueRetries};
-use lambda_runtime::Error;
 use std::collections::HashMap;
+use tower::BoxError;
 
 /// A queue worker
 ///
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 pub async fn worker(
     records: Vec<QueueRecord>,
     _secrets: &HashMap<String, String>,
-) -> Result<QueueRetries, Error> {
+) -> Result<QueueRetries, BoxError> {
     let mut retries = QueueRetries::new();
 
     let record = match records.first() {

--- a/examples/src/basic/worker.rs
+++ b/examples/src/basic/worker.rs
@@ -1,6 +1,8 @@
 use kinetics::macros::worker;
 use kinetics::tools::queue::{Record as QueueRecord, Retries as QueueRetries};
 use std::collections::HashMap;
+// As an example use a general-purpose type-erased error from tower.
+// Custom errors would work as well.
 use tower::BoxError;
 
 /// A queue worker

--- a/examples/src/database.rs
+++ b/examples/src/database.rs
@@ -1,9 +1,10 @@
 use aws_sdk_dynamodb::types::AttributeValue::S;
 use aws_sdk_dynamodb::Client;
+use http::{Request, Response, StatusCode};
 use kinetics::macros::endpoint;
-use lambda_http::{Body, Error, Request, Response};
 use serde_json::json;
 use std::collections::HashMap;
+use tower::BoxError;
 
 /// Simply put an item into DB and then retrieve it
 ///
@@ -14,9 +15,9 @@ use std::collections::HashMap;
     environment = {"TABLE_NAME": "mytable"},
 )]
 pub async fn database(
-    _event: Request,
+    _event: Request<()>,
     _secrets: &HashMap<String, String>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<String>, BoxError> {
     let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
     let client = Client::new(&config);
     let env = std::env::vars().collect::<HashMap<_, _>>();
@@ -43,11 +44,10 @@ pub async fn database(
         .unwrap();
 
     let name = item.get("name").unwrap().as_s().unwrap();
-
     let resp = Response::builder()
-        .status(200)
+        .status(StatusCode::OK)
         .header("content-type", "application/json")
-        .body(json!({"success": true, name: name}).to_string().into())
+        .body(json!({"success": true, "name": name}).to_string())
         .map_err(Box::new)?;
 
     Ok(resp)

--- a/examples/src/database.rs
+++ b/examples/src/database.rs
@@ -4,6 +4,8 @@ use http::{Request, Response, StatusCode};
 use kinetics::macros::endpoint;
 use serde_json::json;
 use std::collections::HashMap;
+// As an example use a general-purpose type-erased error from tower.
+// Custom errors would work as well.
 use tower::BoxError;
 
 /// Simply put an item into DB and then retrieve it

--- a/examples/src/environment.rs
+++ b/examples/src/environment.rs
@@ -1,7 +1,8 @@
+use http::{Request, Response};
 use kinetics::macros::endpoint;
-use lambda_http::{Body, Error, Request, Response};
 use serde_json::json;
 use std::collections::HashMap;
+use tower::BoxError;
 
 /// REST API endpoint which responds with a value of environment variable
 ///
@@ -12,9 +13,9 @@ use std::collections::HashMap;
     environment = {"SOME_VAR": "someval"},
 )]
 pub async fn environment(
-    _event: Request,
+    _event: Request<String>,
     _secrets: &HashMap<String, String>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<String>, BoxError> {
     let env = std::env::vars().collect::<HashMap<_, _>>();
 
     let resp = Response::builder()
@@ -22,10 +23,8 @@ pub async fn environment(
         .header("content-type", "text/html")
         .body(
             json!({"SOME_VAR": env.get("SOME_VAR").unwrap_or(&String::from("Not set"))})
-                .to_string()
-                .into(),
-        )
-        .map_err(Box::new)?;
+                .to_string(),
+        )?;
 
     Ok(resp)
 }

--- a/examples/src/environment.rs
+++ b/examples/src/environment.rs
@@ -2,6 +2,8 @@ use http::{Request, Response};
 use kinetics::macros::endpoint;
 use serde_json::json;
 use std::collections::HashMap;
+// As an example use a general-purpose type-erased error from tower.
+// Custom errors would work as well.
 use tower::BoxError;
 
 /// REST API endpoint which responds with a value of environment variable

--- a/examples/src/queue.rs
+++ b/examples/src/queue.rs
@@ -1,24 +1,24 @@
 use crate::basic::worker::worker;
+use http::{Request, Response, StatusCode};
 use kinetics::macros::endpoint;
 use kinetics::tools::queue::Client as QueueClient;
-use lambda_http::{Body, Error, Request, Response};
 use serde_json::json;
 use std::collections::HashMap;
+use tower::BoxError;
 
 /// Send a message to the queue
 #[endpoint(url_path = "/queue")]
 pub async fn queue(
-    _event: Request,
+    _event: Request<Vec<u8>>,
     _secrets: &HashMap<String, String>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<String>, BoxError> {
     let client = QueueClient::from_worker(worker).await?;
     client.send("Test message").await?;
 
     let resp = Response::builder()
-        .status(200)
+        .status(StatusCode::OK)
         .header("content-type", "text/html")
-        .body(json!({"success": true}).to_string().into())
+        .body(json!({"success": true}).to_string())
         .map_err(Box::new)?;
-
     Ok(resp)
 }

--- a/examples/src/queue.rs
+++ b/examples/src/queue.rs
@@ -4,6 +4,8 @@ use kinetics::macros::endpoint;
 use kinetics::tools::queue::Client as QueueClient;
 use serde_json::json;
 use std::collections::HashMap;
+// As an example use a general-purpose type-erased error from tower.
+// Custom errors would work as well.
 use tower::BoxError;
 
 /// Send a message to the queue

--- a/examples/src/secrets.rs
+++ b/examples/src/secrets.rs
@@ -1,7 +1,8 @@
+use http::{Request, Response, StatusCode};
 use kinetics::macros::endpoint;
-use lambda_http::{Body, Error, Request, Response};
 use serde_json::json;
 use std::collections::HashMap;
+use tower::BoxError;
 
 /// Print out a secret value
 ///
@@ -10,9 +11,9 @@ use std::collections::HashMap;
 /// kinetics invoke SecretsSecretsUndrscrendpoint
 #[endpoint(url_path = "/secrets")]
 pub async fn secrets_endpoint(
-    _event: Request,
+    _event: Request<()>,
     secrets: &HashMap<String, String>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<String>, BoxError> {
     println!(
         "Found a secret: {}",
         secrets
@@ -21,9 +22,9 @@ pub async fn secrets_endpoint(
     );
 
     let resp = Response::builder()
-        .status(200)
+        .status(StatusCode::OK)
         .header("content-type", "text/html")
-        .body(json!({"success": true}).to_string().into())
+        .body(json!({"success": true}).to_string())
         .map_err(Box::new)?;
 
     Ok(resp)

--- a/examples/src/secrets.rs
+++ b/examples/src/secrets.rs
@@ -2,6 +2,8 @@ use http::{Request, Response, StatusCode};
 use kinetics::macros::endpoint;
 use serde_json::json;
 use std::collections::HashMap;
+// As an example use a general-purpose type-erased error from tower.
+// Custom errors would work as well.
 use tower::BoxError;
 
 /// Print out a secret value


### PR DESCRIPTION
The new `Body` type represents supported payloads and provides conversions into underlying basic types, such as unit struct, string and vector of bytes. With the new type a user can use either our `Body` implementation or the basic types that are easily extracted from it.

Some dependancies are updated to ranges, since any rigid numbers here would produce inconsistent types. E.g. if we fix a dep to 0.14.0 and a user has the same dep as 0.16.0 - finally it would cause conflicts, because rust handles the same types from different versions of a crate as different.

Type conversion is implemented via `TryFrom` trait, meaning any unexpected conversion would result in error and handler would fail right away. E.g. receiving a `Body::Binary` body in a handler expecting `String` would result in an error if the resulting string is not valid.

All examples are updated to handle general-purpose payloads, which are available via From implementations on the `Body`.