### PR TITLE
Switch from String::try_from to String::from_utf8

### DIFF
--- a/cli/src/tools/http.rs
+++ b/cli/src/tools/http.rs
@@ -53,7 +53,7 @@ impl TryFrom<Body> for String {
         match value {
             Body::Empty => Ok(String::new()),
             Body::Text(chars) => Ok(chars),
-            Body::Binary(bytes) => Ok(String::try_from(bytes)?),
+            Body::Binary(bytes) => Ok(String::from_utf8(bytes)?),
         }
     }
 }


### PR DESCRIPTION
Thus we lower rust version requirement from 1.87.0 to 1.0.0.

The interesting part is that `try_from` just uses `from_utf8` under the hood: https://doc.rust-lang.org/src/alloc/string.rs.html#3254-3269.