### PR TITLE
Use logs period in println

### DIFF
--- a/cli/src/logs.rs
+++ b/cli/src/logs.rs
@@ -63,7 +63,11 @@ pub async fn logs(function_name: &str, crat: &Crate, period: &Option<String>) ->
     if logs_response.events.is_empty() {
         println!(
             "{}",
-            console::style("No logs found for this function in the last hour.").yellow(),
+            console::style(format!(
+                "No logs found for this function in the last {}.",
+                period.clone().unwrap_or("1 hour".into())
+            ))
+            .yellow(),
         );
 
         return Ok(());


### PR DESCRIPTION
Output a message of no logs with a reference to the period, provided by user. Fallback to 1 hour.