### PR TITLE
Introduce `--envs` flag for `deploy` command

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -45,6 +45,10 @@ enum Commands {
         #[arg(short, long, default_value_t = 10)]
         max_concurrency: usize,
 
+        /// Deploy only environment variables instead of full deployment
+        #[arg(short, long, action = ArgAction::SetTrue)]
+        envs: bool,
+
         #[arg(value_delimiter = ',')]
         functions: Vec<String>,
     },
@@ -206,8 +210,9 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
         Some(Commands::Deploy {
             functions,
             max_concurrency,
+            envs,
             ..
-        }) => deploy::run(functions, max_concurrency, deploy_config).await,
+        }) => deploy::run(functions, max_concurrency, *envs, deploy_config).await,
         Some(Commands::Destroy {}) => destroy(&crat)
             .await
             .wrap_err("Failed to destroy the project"),

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -1,28 +1,143 @@
-use crate::build::pipeline::Pipeline;
+use crate::build::{pipeline::Pipeline, prepare_crates};
+use crate::client::Client;
+use crate::config::build_config;
 use crate::crat::Crate;
 use crate::function::Function;
 use async_trait::async_trait;
-use eyre::{Ok, WrapErr};
+use eyre::WrapErr;
+use reqwest::StatusCode;
+use serde_json::json;
+
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// The entry point to run the command
 pub async fn run(
     deploy_functions: &[String],
     max_concurrency: &usize,
+    is_only_envs: bool,
+    deploy_config: Option<Arc<dyn DeployConfig>>,
+) -> eyre::Result<()> {
+    if is_only_envs {
+        envs(deploy_functions).await?;
+    } else {
+        full(deploy_functions, *max_concurrency, deploy_config).await?;
+    }
+
+    Ok(())
+}
+
+/// Deploy only environment variables for functions
+async fn envs(deploy_functions: &[String]) -> eyre::Result<()> {
+    println!("{}...", console::style("Provisioning envs").green().bold());
+    let crat = Crate::from_current_dir()?;
+
+    let functions: Vec<Function> = prepare_crates(
+        PathBuf::from(build_config()?.kinetics_path),
+        &crat,
+        deploy_functions,
+    )?
+    .iter()
+    .filter(|f| f.is_deploying)
+    .cloned()
+    .collect();
+
+    if functions.is_empty() {
+        println!("{}", console::style("No functions found").yellow().bold(),);
+        return Ok(());
+    }
+
+    // Collect environment variables from all functions
+    // {"<Function name>": {"<Env>": "<Value>"}}
+    let mut envs = HashMap::new();
+
+    for function in &functions {
+        let function_envs = function.environment()?;
+
+        let envs_string = function_envs
+            .keys()
+            .map(|k| k.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        println!(
+            "{} {}",
+            console::style(function.name.clone()).bold(),
+            if envs_string.is_empty() {
+                console::style("None").dim().yellow()
+            } else {
+                console::style(envs_string.as_str()).dim()
+            }
+        );
+
+        envs.insert(function.name.clone(), function_envs);
+    }
+
+    let client = Client::new(false)?;
+
+    let result = client
+        .post("/stack/deploy/envs")
+        .json(&json!({
+            "crate_name": crat.name.clone(),
+            "functions": envs,
+        }))
+        .send()
+        .await
+        .wrap_err("Request to update envs failed")?;
+
+    let status = result.status();
+    let response_text = result.text().await?;
+    log::debug!("Got status from /stack/deploy/envs: {}", status);
+    log::debug!("Got response from /stack/deploy/envs: {}", response_text);
+
+    let response_json: serde_json::Value = serde_json::from_str(&response_text)
+        .wrap_err("Failed to parse response from the backend as JSON")?;
+
+    if StatusCode::OK != status {
+        log::error!("Got error response: {}", response_text);
+        return Err(eyre::eyre!("Failed to deploy envs"));
+    }
+
+    let default_arr = serde_json::Value::Array(vec![]);
+    let default_vec = vec![];
+
+    let fails = response_json
+        .get("fails")
+        .unwrap_or(&default_arr)
+        .as_array()
+        .unwrap_or(&default_vec);
+
+    if !fails.is_empty() {
+        return Err(eyre::eyre!(
+            "Failed to provision envs for: {}",
+            fails
+                .iter()
+                .map(|v| v.as_str().unwrap_or("unknown"))
+                .collect::<Vec<&str>>()
+                .join(", "),
+        ));
+    }
+
+    println!("{}", console::style("Done").green().bold(),);
+    Ok(())
+}
+
+/// Do full deployment of requested functions
+async fn full(
+    deploy_functions: &[String],
+    max_concurrency: usize,
     deploy_config: Option<Arc<dyn DeployConfig>>,
 ) -> eyre::Result<()> {
     Pipeline::builder()
-        .set_max_concurrent(*max_concurrency)
+        .set_max_concurrent(max_concurrency)
         .with_deploy_enabled(true)
         .with_deploy_config(deploy_config)
         .set_crat(Crate::from_current_dir()?)
         .build()
         .wrap_err("Failed to build pipeline")?
         .run(deploy_functions)
-        .await?;
-
-    Ok(())
+        .await
 }
 
 #[async_trait]


### PR DESCRIPTION
Extends the `deploy` command to allow deploying only envs of a one or more functions. This is much faster than building and deploying entire function.