### PR TITLE
Restructure CLI commands hierarchy

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -251,7 +251,7 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
         }) => {
             return list(&crat, *verbose)
                 .await
-                .wrap_err("Failed to destroy the project")
+                .wrap_err("Failed to list functions")
                 .map_err(Error::from);
         }
         Some(Commands::Func {


### PR DESCRIPTION
* Creates `func` and `proj` subcommands and moves some of the root commands there
* Keeps most frequently used commands in the root.