### PR TITLE
A command to list projects

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -7,7 +7,7 @@ use crate::error::Error;
 use crate::function::Type as FunctionType;
 use crate::init::init;
 use crate::invoke::invoke;
-use crate::list::list;
+use crate::list;
 use crate::logger::Logger;
 use crate::login::login;
 use crate::logout::logout;
@@ -189,6 +189,9 @@ enum Commands {
         remote: bool,
     },
 
+    /// List projects
+    List {},
+
     /// Logout from Kinetics platform
     Logout {},
 }
@@ -224,7 +227,7 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
             .await
             .map_err(Error::from);
         }
-
+        Some(Commands::List {}) => return list::projects().await,
         _ => {}
     }
 
@@ -262,7 +265,7 @@ pub async fn run(deploy_config: Option<Arc<dyn DeployConfig>>) -> Result<(), Err
         Some(Commands::Func {
             command: Some(FunctionsCommands::List { verbose }),
         }) => {
-            return list(&crat, *verbose)
+            return list::functions(&crat, *verbose)
                 .await
                 .wrap_err("Failed to list functions")
                 .map_err(Error::from);

--- a/cli/src/crat.rs
+++ b/cli/src/crat.rs
@@ -134,6 +134,10 @@ impl Crate {
     }
 
     pub async fn status(&self) -> eyre::Result<StatusResponseBody> {
+        Self::status_by_name(&self.name).await
+    }
+
+    pub async fn status_by_name(name: &str) -> eyre::Result<StatusResponseBody> {
         let client = Client::new(false)?;
 
         #[derive(serde::Serialize, Debug)]
@@ -144,7 +148,7 @@ impl Crate {
         let result = client
             .post("/stack/status")
             .json(&serde_json::json!(JsonBody {
-                name: self.name.clone()
+                name: name.to_owned()
             }))
             .send()
             .await

--- a/cli/src/list.rs
+++ b/cli/src/list.rs
@@ -1,8 +1,10 @@
 use crate::client::Client;
 use crate::crat::Crate;
+use crate::error::Error;
 use crate::function::Function;
 use crate::project::Project;
 use color_eyre::owo_colors::OwoColorize;
+use futures::stream::{self, StreamExt};
 use kinetics_parser::{ParsedFunction, Parser, Role};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -171,7 +173,7 @@ fn simple(functions: &[ParsedFunction], project_base_url: &str) -> eyre::Result<
 /// Prints out the list of all functions
 ///
 /// With some extra information
-pub async fn list(current_crate: &Crate, is_verbose: bool) -> eyre::Result<()> {
+pub async fn functions(current_crate: &Crate, is_verbose: bool) -> eyre::Result<()> {
     let functions = Parser::new(Some(&current_crate.path))?.functions;
     let project_base_url = Project::new(current_crate.to_owned()).base_url().await?;
 
@@ -233,6 +235,42 @@ pub async fn list(current_crate: &Crate, is_verbose: bool) -> eyre::Result<()> {
     let (width, _) = get_terminal_size();
 
     verbose(&endpoint_rows, &cron_rows, &worker_rows, width);
+
+    Ok(())
+}
+
+/// Prints out the list of all projects
+pub async fn projects() -> Result<(), Error> {
+    #[derive(Tabled, Clone)]
+    struct ProjectRow {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "Status")]
+        status: String,
+    }
+
+    let projects = stream::iter(Project::list().await?)
+        .map(async |name| {
+            Crate::status_by_name(&name).await.map(|status| ProjectRow {
+                name,
+                status: status.status,
+            })
+        })
+        .buffer_unordered(3) // Run up to 3 requests concurrently.
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let (width, _) = get_terminal_size();
+
+    let settings = Settings::default()
+        .with(Width::wrap(width).priority(Priority::max(true)))
+        .with(Width::increase(width));
+
+    let mut table = Table::new(projects.to_vec());
+    table.with(Style::modern()).with(settings);
+    println!("Projects\n{}", table);
 
     Ok(())
 }

--- a/cli/src/project.rs
+++ b/cli/src/project.rs
@@ -69,6 +69,24 @@ impl Project {
         Err(eyre::eyre!("Failed to load project information"))
     }
 
+    /// Get a list of projects created by the account
+    pub async fn list() -> eyre::Result<Vec<String>> {
+        #[derive(Debug, Deserialize, Serialize)]
+        struct ProjectsResponse {
+            /// A list of project names
+            projects: Vec<String>,
+        }
+
+        Client::new(false)?
+            .request::<(), ProjectsResponse>("/project/list", ())
+            .await
+            .wrap_err(Error::new(
+                "Failed to fetch projects list",
+                Some("Try again in a few seconds."),
+            ))
+            .map(|r| r.projects)
+    }
+
     /// Load the project cache from disk with automatic refresh logic
     async fn load_cache(&self) -> eyre::Result<Cache> {
         let cache_path = Self::cache_path()?;


### PR DESCRIPTION
- Introduce a top level command `list`.
- The command:
  -  fetches project names from backend;
  - use names to query status of each project and fills in status for each of the projects;
  - writes project names and statuses in a table.