### PR TITLE
No clone on observability

### DIFF
--- a/cli/src/commands/deploy/runner.rs
+++ b/cli/src/commands/deploy/runner.rs
@@ -25,8 +25,8 @@ impl Runner for DeployRunner<'_> {
 
         // DataDog API key only needed during deployment, to send it to the backend
         if project
-            .clone()
             .observability
+            .as_ref()
             .filter(|o| o.dd_api_key.is_empty())
             .is_some()
         {
@@ -105,7 +105,7 @@ impl DeployRunner<'_> {
         let result = client
             .post("/stack/deploy/envs")
             .json(&stack::deploy::envs::Request {
-                project_name: project.name.clone(),
+                project_name: project.name,
                 functions: envs,
             })
             .send()

--- a/cli/src/project/config_file.rs
+++ b/cli/src/project/config_file.rs
@@ -57,28 +57,21 @@ impl ConfigFile {
 
         let result: Result<ConfigFile, toml::de::Error> = toml::from_str(&toml_string);
 
-        let mut config = if result.is_err() {
-            return Err(eyre::eyre!(
-                "Failed to parse kinetics.toml: {}\nCheck docs at https://github.com/ottofeller/kinetics",
-                result.err().unwrap().message().to_string()
-            ));
-        } else {
-            result.unwrap()
-        };
+        let mut config = result.map_err(|error| eyre::eyre!(
+            "Failed to parse kinetics.toml: {}\nCheck docs at https://github.com/ottofeller/kinetics",
+            error.message().to_string()
+        ))?;
 
         // Set the path to the directory containing kinetics.toml
         config.path = path.clone();
 
-        match config.observability.clone() {
-            Some(observability) => {
-                if observability.dd_api_key_env.is_empty() {
-                    return Err(eyre::eyre!(
-                        "When [observability] section presented in kinetics.toml
+        if let Some(observability) = config.observability.as_ref() {
+            if observability.dd_api_key_env.is_empty() {
+                return Err(eyre::eyre!(
+                    "When [observability] section presented in kinetics.toml
                         both dd_api_key and service_name properties must be specified"
-                    ));
-                }
+                ));
             }
-            None => {}
         }
 
         // If project name is explicitly set in kinetics.toml, return it right away
@@ -127,9 +120,7 @@ impl TryFrom<ConfigFile> for Project {
     fn try_from(cfg: ConfigFile) -> eyre::Result<Self> {
         let mut project = Project::new(cfg.path, cfg.project.name).with_kvdb(cfg.kvdb);
 
-        if cfg.observability.is_some() {
-            let observability = cfg.observability.unwrap();
-
+        if let Some(observability) = cfg.observability {
             // Read DataDog API key from env, it's not safe to store it in kinetics config file
             let dd_api_key = std::env::var(&observability.dd_api_key_env).unwrap_or_default();
 


### PR DESCRIPTION
ref suffices, thus no cloning needed.
In addition get rid of unwraps and simplify with destructuring.