### PR TITLE
Project arg

### DIFF
--- a/cli/src/commands/build.rs
+++ b/cli/src/commands/build.rs
@@ -6,12 +6,17 @@ use crate::{
     writer::Writer,
 };
 use runner::BuildRunner;
+use std::path::PathBuf;
 
 #[derive(clap::Args, Clone)]
 pub(crate) struct BuildCommand {
     /// Comma-separated list of function names to build (if not specified, all functions will be built)
     #[arg(short, long, value_delimiter = ',')]
     pub(crate) functions: Vec<String>,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    pub(crate) project: Option<PathBuf>,
 }
 
 impl Runnable for BuildCommand {

--- a/cli/src/commands/build/runner.rs
+++ b/cli/src/commands/build/runner.rs
@@ -14,7 +14,7 @@ pub(crate) struct BuildRunner<'a> {
 impl Runner for BuildRunner<'_> {
     /// Build one or more functions
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
 
         Pipeline::builder(self.writer)
             .with_deploy_enabled(false)

--- a/cli/src/commands/cicd/init.rs
+++ b/cli/src/commands/cicd/init.rs
@@ -3,12 +3,17 @@ use crate::error::Error;
 use crate::runner::{Runnable, Runner};
 use crate::writer::Writer;
 use serde_json::json;
+use std::path::PathBuf;
 
 #[derive(clap::Args, Clone)]
 pub(crate) struct InitCommand {
     /// Create a GitHub workflow file.
     #[arg(short, long, action = clap::ArgAction::SetTrue, required = false)]
     github: bool,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for InitCommand {
@@ -30,7 +35,7 @@ impl Runner for InitRunner<'_> {
     ///
     /// Currently only supports GitHub, but expected to expand in the future.
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
 
         self.writer.text(&format!(
             "{}\n",

--- a/cli/src/commands/deploy.rs
+++ b/cli/src/commands/deploy.rs
@@ -3,6 +3,7 @@ use crate::runner::{Runnable, Runner};
 use crate::writer::Writer;
 use clap::ArgAction;
 use runner::DeployRunner;
+use std::path::PathBuf;
 
 #[derive(clap::Args, Clone)]
 pub(crate) struct DeployCommand {
@@ -25,6 +26,10 @@ pub(crate) struct DeployCommand {
     /// Message to include in the deployment (max 100 characters)
     #[arg(short, long)]
     message: Option<String>,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    pub(crate) project: Option<PathBuf>,
 }
 
 impl Runnable for DeployCommand {

--- a/cli/src/commands/deploy/runner.rs
+++ b/cli/src/commands/deploy/runner.rs
@@ -21,7 +21,7 @@ pub(crate) struct DeployRunner<'a> {
 impl Runner for DeployRunner<'_> {
     /// Invoke the function either locally or remotely
     async fn run(&mut self) -> Result<(), Error> {
-        let project = Project::from_current_dir()?;
+        let project = self.project().await?;
 
         // DataDog API key only needed during deployment, to send it to the backend
         if project

--- a/cli/src/commands/deploy/runner.rs
+++ b/cli/src/commands/deploy/runner.rs
@@ -21,7 +21,7 @@ pub(crate) struct DeployRunner<'a> {
 impl Runner for DeployRunner<'_> {
     /// Invoke the function either locally or remotely
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
 
         // DataDog API key only needed during deployment, to send it to the backend
         if project

--- a/cli/src/commands/envs/list.rs
+++ b/cli/src/commands/envs/list.rs
@@ -17,6 +17,10 @@ pub(crate) struct ListCommand {
     /// When passed shows env vars used by deployed functions
     #[arg(short, long, action = clap::ArgAction::SetTrue)]
     remote: bool,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for ListCommand {
@@ -36,7 +40,7 @@ struct ListRunner<'a> {
 impl Runner for ListRunner<'_> {
     /// Lists all environment variables for all functions in the current crate
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
         let parsed_functions = project
             .parsed_functions()
             .map_err(|e| self.error(None, None, Some(e.into())))?;

--- a/cli/src/commands/func/list.rs
+++ b/cli/src/commands/func/list.rs
@@ -9,6 +9,7 @@ use eyre::Context;
 use kinetics_parser::{Params, ParsedFunction, Role};
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use tabled::settings::{peaker::Priority, style::Style, Settings, Width};
 use tabled::{Table, Tabled};
 use terminal_size::{terminal_size, Height as TerminalHeight, Width as TerminalWidth};
@@ -56,6 +57,10 @@ pub(crate) struct ListCommand {
     /// Show detailed information for each function
     #[arg(short, long)]
     verbose: bool,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for ListCommand {
@@ -77,7 +82,7 @@ struct ListRunner<'a> {
 impl Runner for ListRunner<'_> {
     /// Prints out the list of all functions with some extra information
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
 
         // Initialize client early and fail with clear error if user's logged out
         // If the method is called within other method, then the auth error won't be propogated
@@ -172,7 +177,7 @@ impl ListRunner<'_> {
     }
 
     async fn verbose(&mut self, client: &Client) -> eyre::Result<()> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
         let project_base_url = Project::fetch_one(&project.name).await?.url;
         let mut endpoint_rows = Vec::new();
         let mut cron_rows = Vec::new();

--- a/cli/src/commands/func/logs.rs
+++ b/cli/src/commands/func/logs.rs
@@ -6,6 +6,7 @@ use crate::writer::Writer;
 use chrono::{DateTime, Utc};
 use eyre::Context;
 use serde_json::json;
+use std::path::PathBuf;
 
 #[derive(clap::Args, Clone)]
 pub(crate) struct LogsCommand {
@@ -23,6 +24,10 @@ pub(crate) struct LogsCommand {
     ///
     #[arg(short, long)]
     period: Option<String>,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for LogsCommand {
@@ -42,7 +47,7 @@ struct LogsRunner<'a> {
 impl Runner for LogsRunner<'_> {
     /// Retrieves and displays logs for a specific function
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
 
         // Get all function names without any additional manipulations.
         let all_functions = project

--- a/cli/src/commands/func/stats.rs
+++ b/cli/src/commands/func/stats.rs
@@ -6,6 +6,7 @@ use crate::writer::Writer;
 use color_eyre::owo_colors::OwoColorize as _;
 use eyre::Context;
 use serde_json::json;
+use std::path::PathBuf;
 use std::time::Duration;
 
 #[derive(clap::Args, Clone)]
@@ -25,6 +26,10 @@ pub(crate) struct StatsCommand {
     ///
     #[arg(short, long)]
     period: Option<String>,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for StatsCommand {
@@ -44,7 +49,7 @@ struct StatsRunner<'a> {
 impl Runner for StatsRunner<'_> {
     /// Retrieves and displays run statistics for a specific function
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
 
         // Get all function names without any additional manipulations.
         let all_functions = project.functions()?;

--- a/cli/src/commands/func/toggle.rs
+++ b/cli/src/commands/func/toggle.rs
@@ -6,12 +6,17 @@ use crate::writer::Writer;
 use eyre::Context;
 use http::StatusCode;
 use serde_json::json;
+use std::path::PathBuf;
 
 #[derive(clap::Args, Clone)]
 pub(crate) struct StopCommand {
     /// Function name to stop
     #[arg()]
     name: String,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for StopCommand {
@@ -19,6 +24,7 @@ impl Runnable for StopCommand {
         ToggleRunner {
             name: self.name.clone(),
             op: func::toggle::Op::Stop,
+            project: self.project.clone(),
             writer,
         }
     }
@@ -29,6 +35,10 @@ pub(crate) struct StartCommand {
     /// Function name to start
     #[arg()]
     name: String,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for StartCommand {
@@ -36,6 +46,7 @@ impl Runnable for StartCommand {
         ToggleRunner {
             name: self.name.clone(),
             op: func::toggle::Op::Start,
+            project: self.project.clone(),
             writer,
         }
     }
@@ -44,6 +55,7 @@ impl Runnable for StartCommand {
 struct ToggleRunner<'a> {
     name: String,
     op: func::toggle::Op,
+    project: Option<PathBuf>,
     writer: &'a Writer,
 }
 
@@ -54,7 +66,7 @@ impl Runner for ToggleRunner<'_> {
     /// - For stop operation the function stops receiving requests
     ///   and the endpoint starts responding "Service Unavailable".
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.project).await?;
 
         // Get all function names without any additional manipulations.
         let all_functions = project

--- a/cli/src/commands/invoke.rs
+++ b/cli/src/commands/invoke.rs
@@ -7,6 +7,7 @@ use crate::{
     runner::{Runnable, Runner},
     writer::Writer,
 };
+use std::path::PathBuf;
 use runner::InvokeRunner;
 
 #[derive(clap::Args, Clone)]
@@ -58,6 +59,10 @@ pub(crate) struct InvokeCommand {
     /// Provision a queue. Helpful when you test a function which sends something to queue. Not available when called with --remote flag.
     #[arg(long="with-queue", visible_aliases=["queue"])]
     with_queue: bool,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    pub(crate) project: Option<PathBuf>,
 }
 
 impl Runnable for InvokeCommand {

--- a/cli/src/commands/invoke/local.rs
+++ b/cli/src/commands/invoke/local.rs
@@ -21,7 +21,7 @@ impl InvokeRunner<'_> {
         function: &Function,
         migrations_path: Option<&str>,
     ) -> eyre::Result<()> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
         let home = std::env::var("HOME").wrap_err("Can not read HOME env var")?;
         let mut secrets_envs = HashMap::new();
 

--- a/cli/src/commands/invoke/remote.rs
+++ b/cli/src/commands/invoke/remote.rs
@@ -13,7 +13,7 @@ impl InvokeRunner<'_> {
     /// Resolve function name into URL and call it remotely
     #[allow(clippy::too_many_arguments)]
     pub async fn remote(&self, function: &Function) -> eyre::Result<()> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
         let home = std::env::var("HOME").wrap_err("Can not read HOME env var")?;
         let invoke_dir = Path::new(&home).join(format!(".kinetics/{}", project.name));
         let display_path = format!("{}/src/bin/{}.rs", invoke_dir.display(), function.name);

--- a/cli/src/commands/invoke/runner.rs
+++ b/cli/src/commands/invoke/runner.rs
@@ -14,7 +14,7 @@ pub(crate) struct InvokeRunner<'a> {
 impl Runner for InvokeRunner<'_> {
     /// Invoke the function either locally or remotely
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
 
         // Get function names as well as pull all updates from the code.
         let all_functions = project.parse(

--- a/cli/src/commands/migrations/apply.rs
+++ b/cli/src/commands/migrations/apply.rs
@@ -6,12 +6,17 @@ use crate::writer::Writer;
 use eyre::Context;
 use project::sqldb::connect::Request;
 use serde_json::json;
+use std::path::PathBuf;
 
 #[derive(clap::Args, Clone)]
 pub(crate) struct ApplyCommand {
     /// Relative path to migrations directory
     #[arg(short, long, value_name = "PATH", default_value = "migrations")]
     path: String,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for ApplyCommand {
@@ -31,7 +36,7 @@ struct ApplyRunner<'a> {
 impl<'a> Runner for ApplyRunner<'a> {
     /// Applies migrations to the database
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
         let client = self.api_client().await?;
         let migrations_path = project.path.join(&self.command.path);
 

--- a/cli/src/commands/migrations/create.rs
+++ b/cli/src/commands/migrations/create.rs
@@ -3,6 +3,7 @@ use crate::migrations::Migrations;
 use crate::runner::{Runnable, Runner};
 use crate::writer::Writer;
 use serde_json::json;
+use std::path::PathBuf;
 
 #[derive(clap::Args, Clone)]
 pub(crate) struct CreateCommand {
@@ -13,6 +14,10 @@ pub(crate) struct CreateCommand {
     /// Relative path to migrations directory
     #[arg(short, long, value_name = "PATH", default_value = "migrations")]
     path: String,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for CreateCommand {
@@ -32,7 +37,7 @@ struct CreateRunner<'a> {
 impl Runner for CreateRunner<'_> {
     /// Creates a new database migration file
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
         let migrations_path = project.path.join(&self.command.path);
 
         // Create migrations directory if it doesn't exist

--- a/cli/src/commands/proj/destroy.rs
+++ b/cli/src/commands/proj/destroy.rs
@@ -6,12 +6,17 @@ use crossterm::style::Stylize;
 use eyre::Context;
 use serde_json::json;
 use std::io::{self, Write};
+use std::path::PathBuf;
 
 #[derive(clap::Args, Clone)]
 pub(crate) struct DestroyCommand {
     /// Name of the project to destroy (optional, defaults to current project name)
     #[arg(short, long)]
     name: Option<String>,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for DestroyCommand {
@@ -31,7 +36,7 @@ struct DestroyRunner<'a> {
 impl Runner for DestroyRunner<'_> {
     /// Destroys a project after user confirmation
     async fn run(&mut self) -> Result<(), Error> {
-        let current_project = self.project().await?;
+        let current_project = self.project(&self.command.project).await?;
 
         let project_name = match &self.command.name {
             Some(name) => name.as_str(),

--- a/cli/src/commands/proj/rollback.rs
+++ b/cli/src/commands/proj/rollback.rs
@@ -4,12 +4,17 @@ use crate::runner::{Runnable, Runner};
 use crate::writer::Writer;
 use eyre::Context;
 use serde_json::json;
+use std::path::PathBuf;
 
 #[derive(clap::Args, Clone)]
 pub(crate) struct RollbackCommand {
     /// Specific version to rollback to (optional)
     #[arg(short, long)]
     version: Option<u32>,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for RollbackCommand {
@@ -32,7 +37,7 @@ impl Runner for RollbackRunner<'_> {
     /// Consequent rollbacks are possible and will revert one version at a time
     /// If version is specified, rollback to that specific version
     async fn run(&mut self) -> Result<(), Error> {
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
         let client = self.api_client().await?;
 
         let versions: stack::versions::Response = client

--- a/cli/src/commands/proj/versions.rs
+++ b/cli/src/commands/proj/versions.rs
@@ -6,17 +6,26 @@ use color_eyre::owo_colors::OwoColorize;
 use crossterm::style::Stylize;
 use eyre::Context;
 use serde_json::{json, Value};
+use std::path::PathBuf;
 
 #[derive(clap::Args, Clone)]
-pub(crate) struct VersionsCommand {}
+pub(crate) struct VersionsCommand {
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
+}
 
 impl Runnable for VersionsCommand {
     fn runner(&self, writer: &Writer) -> impl Runner {
-        VersionsRunner { writer }
+        VersionsRunner {
+            command: self.clone(),
+            writer,
+        }
     }
 }
 
 struct VersionsRunner<'a> {
+    command: VersionsCommand,
     writer: &'a Writer,
 }
 
@@ -30,7 +39,7 @@ impl Runner for VersionsRunner<'_> {
             console::style("Fetching versions").green().bold()
         ))?;
 
-        let project = self.project().await?;
+        let project = self.project(&self.command.project).await?;
 
         let mut versions = client
             .request::<_, stack::versions::Response>(

--- a/cli/src/project.rs
+++ b/cli/src/project.rs
@@ -86,11 +86,6 @@ impl Project {
         ConfigFile::from_path(path)?.try_into()
     }
 
-    /// Creates a new project instance from the current directory
-    pub fn from_current_dir() -> eyre::Result<Self> {
-        Self::from_path(std::env::current_dir().wrap_err("Failed to get current dir")?)
-    }
-
     /// Get project by name, with automatic cache management.
     ///
     /// Returns an error if the API request fails or if there are filesystem issues

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -1,5 +1,8 @@
+use eyre::Context as _;
+
 use crate::{api::client::Client, error::Error, project::Project, writer::Writer};
 use std::error::Error as StdError;
+use std::path::PathBuf;
 
 pub(crate) trait Runner {
     /// Construct the API client instance
@@ -18,8 +21,12 @@ pub(crate) trait Runner {
     }
 
     /// Current working project
-    async fn project(&self) -> Result<Project, Error> {
-        Project::from_current_dir()
+    ///
+    /// Provide relative path to the project directory from cwd.
+    async fn project(&self, rel_path: &Option<PathBuf>) -> Result<Project, Error> {
+        std::env::current_dir()
+            .wrap_err("Failed to get current dir")
+            .and_then(|cwd| Project::from_path(cwd.join(rel_path.clone().unwrap_or_default())))
             .map_err(|e| self.error(Some("Project error"), Some(&e.to_string()), None))
     }
 

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -19,17 +19,8 @@ pub(crate) trait Runner {
 
     /// Current working project
     async fn project(&self) -> Result<Project, Error> {
-        let project = Project::from_current_dir();
-
-        if project.is_err() {
-            return Err(self.error(
-                Some("Project error"),
-                Some(&project.err().unwrap().to_string()),
-                None,
-            ));
-        }
-
-        Ok(project?)
+        Project::from_current_dir()
+            .map_err(|e| self.error(Some("Project error"), Some(&e.to_string()), None))
     }
 
     /// Run the command


### PR DESCRIPTION
All commands working with project now have an optional `--project` argument. The argument receives a path from CWD to the project and when omitted CWD is used.

This enables:
- calling `kinetics` from arbitrary dirs;
- including calling `kinetics` from a workspace root for projects located within workspace members.