### PR TITLE
Update worker naming in queues for workspaces

### DIFF
--- a/cli/src/tools/queue.rs
+++ b/cli/src/tools/queue.rs
@@ -87,7 +87,10 @@ impl Client {
                             &std::env::var("KINETICS_USERNAME")
                                 .expect("KINETICS_USERNAME is not set"),
                             project_name,
-                            &ParsedFunction::to_local_name(&[&function_path.replace("::", "/")]),
+                            &ParsedFunction::to_local_name(&[
+                                &project_name,
+                                &function_path.replace("::", "/"),
+                            ]),
                         ))
                     })
                     .expect("Queue name is not set");


### PR DESCRIPTION
otherwise the name is incorrect and the worker can't be found.