### PR TITLE
Skip config check for standalone crates

### DIFF
--- a/cli/src/project/workspace.rs
+++ b/cli/src/project/workspace.rs
@@ -104,6 +104,9 @@ impl Workspace {
             })
             .collect();
 
+        // For a standalone crate workspace construct errors if kinetics.toml exists.
+        // The reason is that in this case the config is present at root and in the member
+        // (since they are the same entity), and a check for no config conflicts fails.
         let is_standalone_crate = members_configs.len() == 1
             && members_configs
                 .first()

--- a/cli/src/project/workspace.rs
+++ b/cli/src/project/workspace.rs
@@ -104,7 +104,12 @@ impl Workspace {
             })
             .collect();
 
-        if workspace_config.exists() && !members_configs.is_empty() {
+        let is_standalone_crate = members_configs.len() == 1
+            && members_configs
+                .first()
+                .is_some_and(|c| *c == workspace_config);
+
+        if !is_standalone_crate && workspace_config.exists() && !members_configs.is_empty() {
             eyre::bail!("Workspace is not allowed to have `kinetics.toml` within its root and within its members at the same time.");
         }
 


### PR DESCRIPTION
Currently there is a bug: for a standalone crate workspace construct errors if `kinetics.toml` exists. The reason is that in this case the config is present at root and in the member (since they are the same entity), and a check for no config conflicts fails.

We need to ensure no clash of configs between workspace root and members only for real workspaces. For standalone crate it's not required.