### PR TITLE
Add org-scoped project cache and fix project list

### DIFF
--- a/cli/src/api/projects.rs
+++ b/cli/src/api/projects.rs
@@ -1,4 +1,3 @@
-use crate::project::Project;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -8,7 +7,7 @@ pub struct Response {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Request {
-    pub project: Project,
+    pub org: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/cli/src/commands/deploy/runner.rs
+++ b/cli/src/commands/deploy/runner.rs
@@ -46,6 +46,14 @@ impl Runner for DeployRunner<'_> {
             self.deploy_all(project).await?;
         }
 
+        Project::clear_cache().map_err(|e| {
+            self.error(
+                Some("Failed to clear project cache"),
+                Some(&e.to_string()),
+                Some(e.into()),
+            )
+        })?;
+
         self.writer.json(json!({"success": true}))?;
         Ok(())
     }

--- a/cli/src/commands/func/list.rs
+++ b/cli/src/commands/func/list.rs
@@ -178,7 +178,9 @@ impl ListRunner<'_> {
 
     async fn verbose(&mut self, client: &Client) -> eyre::Result<()> {
         let project = self.project(&self.command.project).await?;
-        let project_base_url = Project::fetch_one(&project.name).await?.url;
+        let project_base_url = Project::fetch_one(&project.name, project.org.as_deref())
+            .await?
+            .url;
         let mut endpoint_rows = Vec::new();
         let mut cron_rows = Vec::new();
         let mut worker_rows = Vec::new();

--- a/cli/src/commands/invoke/remote.rs
+++ b/cli/src/commands/invoke/remote.rs
@@ -34,7 +34,9 @@ impl InvokeRunner<'_> {
             Some(url_path) if !url_path.is_empty() => {
                 format!(
                     "{}/{}",
-                    Project::fetch_one(&function.project.name).await?.url(),
+                    Project::fetch_one(&function.project.name, function.project.org.as_deref())
+                        .await?
+                        .url(),
                     url_path
                 )
             }

--- a/cli/src/commands/proj/destroy.rs
+++ b/cli/src/commands/proj/destroy.rs
@@ -43,7 +43,7 @@ impl Runner for DestroyRunner<'_> {
             None => current_project.name.as_str(),
         };
 
-        let project = match Project::fetch_one(project_name).await {
+        let project = match Project::fetch_one(project_name, current_project.org.as_deref()).await {
             Ok(project) => project,
 
             Err(_) => {

--- a/cli/src/commands/proj/destroy.rs
+++ b/cli/src/commands/proj/destroy.rs
@@ -102,6 +102,14 @@ impl Runner for DestroyRunner<'_> {
             console::style("Project destroyed").green()
         ))?;
 
+        Project::clear_cache().map_err(|e| {
+            self.error(
+                Some("Failed to clear project cache"),
+                Some(&e.to_string()),
+                Some(e.into()),
+            )
+        })?;
+
         self.writer.json(json!({"success": true}))?;
         Ok(())
     }

--- a/cli/src/commands/proj/list.rs
+++ b/cli/src/commands/proj/list.rs
@@ -4,11 +4,17 @@ use crate::runner::{Runnable, Runner};
 use crate::writer::Writer;
 use color_eyre::owo_colors::OwoColorize;
 use serde_json::{json, Value};
+use std::path::PathBuf;
 
 #[derive(clap::Args, Clone)]
 pub(crate) struct ListCommand {
+    /// Organization to list projects for. Defaults to the current project's org from kinetics.toml.
     #[arg(long)]
     org: Option<String>,
+
+    /// Relative path to the project directory
+    #[arg(long)]
+    project: Option<PathBuf>,
 }
 
 impl Runnable for ListCommand {
@@ -16,6 +22,7 @@ impl Runnable for ListCommand {
         ListRunner {
             writer,
             org: self.org.clone(),
+            project: self.project.clone(),
         }
     }
 }
@@ -23,6 +30,7 @@ impl Runnable for ListCommand {
 struct ListRunner<'a> {
     writer: &'a Writer,
     org: Option<String>,
+    project: Option<PathBuf>,
 }
 
 impl Runner for ListRunner<'_> {
@@ -36,7 +44,10 @@ impl Runner for ListRunner<'_> {
             console::style("Fetching projects").green().bold()
         ))?;
 
-        let projects = Project::fetch_all(self.org.as_deref())
+        let current_project = self.project(&self.project).await?;
+        let org = self.org.as_deref().or(current_project.org.as_deref());
+
+        let projects = Project::fetch_all(org)
             .await
             .map_err(|e| self.server_error(Some(e.into())))?;
 

--- a/cli/src/commands/proj/list.rs
+++ b/cli/src/commands/proj/list.rs
@@ -6,16 +6,23 @@ use color_eyre::owo_colors::OwoColorize;
 use serde_json::{json, Value};
 
 #[derive(clap::Args, Clone)]
-pub(crate) struct ListCommand;
+pub(crate) struct ListCommand {
+    #[arg(long)]
+    org: Option<String>,
+}
 
 impl Runnable for ListCommand {
     fn runner(&self, writer: &Writer) -> impl Runner {
-        ListRunner { writer }
+        ListRunner {
+            writer,
+            org: self.org.clone(),
+        }
     }
 }
 
 struct ListRunner<'a> {
     writer: &'a Writer,
+    org: Option<String>,
 }
 
 impl Runner for ListRunner<'_> {
@@ -29,7 +36,7 @@ impl Runner for ListRunner<'_> {
             console::style("Fetching projects").green().bold()
         ))?;
 
-        let projects = Project::fetch_all()
+        let projects = Project::fetch_all(self.org.as_deref())
             .await
             .map_err(|e| self.server_error(Some(e.into())))?;
 

--- a/cli/src/function.rs
+++ b/cli/src/function.rs
@@ -150,7 +150,9 @@ impl Function {
 
         Ok(format!(
             "{}{}",
-            Project::fetch_one(&self.project.name).await?.url(),
+            Project::fetch_one(&self.project.name, self.project.org.as_deref())
+                .await?
+                .url(),
             url_path
         ))
     }

--- a/cli/src/project.rs
+++ b/cli/src/project.rs
@@ -106,8 +106,8 @@ impl Project {
     ///
     /// Returns an error if the API request fails or if there are filesystem issues
     /// with reading/writing the cache.
-    pub async fn fetch_one(name: &str) -> eyre::Result<Self> {
-        let cache = Cache::new().await?;
+    pub async fn fetch_one(name: &str, org: Option<&str>) -> eyre::Result<Self> {
+        let cache = Cache::new(org).await?;
 
         cache
             .get(name)
@@ -118,8 +118,8 @@ impl Project {
     ///
     /// Returns an error if the API request fails or if there are filesystem issues
     /// with reading/writing the cache.
-    pub async fn fetch_all() -> eyre::Result<Vec<Self>> {
-        Cache::new()
+    pub async fn fetch_all(org: Option<&str>) -> eyre::Result<Vec<Self>> {
+        Cache::new(org)
             .await
             .map(|cache| cache.projects.into_values().collect())
     }

--- a/cli/src/project/cache.rs
+++ b/cli/src/project/cache.rs
@@ -1,4 +1,5 @@
 use crate::api::client::Client;
+use crate::api::orgs::validators;
 use crate::api::projects;
 use crate::config::build_config;
 use crate::error::Error;
@@ -23,8 +24,8 @@ pub(super) struct Cache {
 
 impl Cache {
     /// Load the project cache from disk with automatic refresh logic
-    pub(super) async fn new() -> eyre::Result<Self> {
-        let cache_path = Self::path()?;
+    pub(super) async fn new(org: Option<&str>) -> eyre::Result<Self> {
+        let cache_path = Self::path(org)?;
 
         let cache: Option<Self> = if !cache_path.exists() {
             // Create the cache directory if it doesn't exist
@@ -55,7 +56,7 @@ impl Cache {
         // Load projects and populate cache if failed to read from disk
         let cache = match cache {
             Some(x) => x,
-            None => Self::load().await?,
+            None => Self::load(org).await?,
         };
 
         // Save cache to the file
@@ -63,7 +64,7 @@ impl Cache {
             .inspect_err(|e| log::error!("Failed to serialize project cache: {e:?}"))
             .wrap_err("Failed to process cache")?;
 
-        let cache_path = Self::path()?;
+        let cache_path = Self::path(org)?;
 
         fs::write(&cache_path, cache_json)
             .inspect_err(|e| log::error!("Failed to write cache file {cache_path:?}: {e:?}"))
@@ -81,26 +82,59 @@ impl Cache {
     }
 
     pub(super) fn clear() -> eyre::Result<()> {
-        let cache_path = Self::path()?;
+        let cache_dir = PathBuf::from(build_config()?.kinetics_path);
 
-        if cache_path.exists() {
-            fs::remove_file(&cache_path)
-                .inspect_err(|e| log::error!("Failed to remove cache file {cache_path:?}: {e:?}"))
+        if !cache_dir.exists() {
+            return Ok(());
+        }
+
+        for entry in fs::read_dir(&cache_dir)
+            .inspect_err(|e| log::error!("Failed to read cache directory {cache_dir:?}: {e:?}"))
+            .wrap_err("Failed to clear the projects cache")?
+        {
+            let entry = entry
+                .inspect_err(|e| log::error!("Failed to read cache entry in {cache_dir:?}: {e:?}"))
                 .wrap_err("Failed to clear the projects cache")?;
+            let path = entry.path();
+            let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+
+            if file_name == ".projects" || file_name.starts_with(".projects.") {
+                fs::remove_file(&path)
+                    .inspect_err(|e| log::error!("Failed to remove cache file {path:?}: {e:?}"))
+                    .wrap_err("Failed to clear the projects cache")?;
+            }
         }
 
         Ok(())
     }
 
     /// Get the static cache path for storing project information.
-    fn path() -> eyre::Result<PathBuf> {
-        Ok(PathBuf::from(build_config()?.kinetics_path).join(".projects"))
+    fn path(org: Option<&str>) -> eyre::Result<PathBuf> {
+        let file_name = match org {
+            Some(org) => {
+                if !validators::Name::validate(org) {
+                    return Err(eyre::eyre!(validators::Name::message()));
+                }
+
+                format!(".projects.{org}")
+            }
+            None => ".projects".to_string(),
+        };
+
+        Ok(PathBuf::from(build_config()?.kinetics_path).join(file_name))
     }
 
-    async fn load() -> eyre::Result<Self> {
+    async fn load(org: Option<&str>) -> eyre::Result<Self> {
         let response = Client::new(false)
             .await?
-            .request::<(), projects::Response>("/projects", ())
+            .request::<projects::Request, projects::Response>(
+                "/projects",
+                projects::Request {
+                    org: org.map(str::to_owned),
+                },
+            )
             .await
             .wrap_err(Error::new(
                 "Failed to fetch project information",

--- a/cli/src/project/cache.rs
+++ b/cli/src/project/cache.rs
@@ -95,12 +95,14 @@ impl Cache {
             let entry = entry
                 .inspect_err(|e| log::error!("Failed to read cache entry in {cache_dir:?}: {e:?}"))
                 .wrap_err("Failed to clear the projects cache")?;
+
             let path = entry.path();
             let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
                 continue;
             };
 
-            if file_name == ".projects" || file_name.starts_with(".projects.") {
+            // Project caches include `.projects` and org-scoped `.projects.<org>` files.
+            if file_name.starts_with(".projects") {
                 fs::remove_file(&path)
                     .inspect_err(|e| log::error!("Failed to remove cache file {path:?}: {e:?}"))
                     .wrap_err("Failed to clear the projects cache")?;


### PR DESCRIPTION
Adds org-scoped project listing via `kinetics proj list --org <name>` while keeping personal project listing unchanged. 

Project cache and lookup are now scoped by owner, so personal and org projects with the same name do not collide.