### PR TITLE
Move lambda dependency versions to manifest

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -81,7 +81,6 @@ url = "2.5.8"
 users = "0.11.0"
 walkdir = "2.5.0"
 
-# Keep in sync with CLI dependencies manually.
 [package.metadata.kinetics.dependencies.common]
 aws-config = { version = "1.8.15" }
 aws-sdk-sqs = { version = "1.97.0" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -80,3 +80,21 @@ twox-hash = "2.1.2"
 url = "2.5.8"
 users = "0.11.0"
 walkdir = "2.5.0"
+
+# Keep in sync with CLI dependencies manually.
+[package.metadata.kinetics.dependencies.common]
+aws-config = { version = "1.8.15" }
+aws-sdk-sqs = { version = "1.97.0" }
+aws-sdk-ssm = { version = "1.59.0" }
+aws_lambda_events = { version = "1.1.2" }
+reqwest = { version = "0.13.2", default-features = false, features = ["default-tls"] }
+serde_json = { version = "1.0.149" }
+tokio = { version = "1.51.1", features = ["full"] }
+tower = { version = "^0" }
+
+[package.metadata.kinetics.dependencies.endpoint]
+http = { version = "^1.0" }
+lambda_http = { version = "^1.0" }
+
+[package.metadata.kinetics.dependencies.cron]
+lambda_runtime = { version = "^1.0" }

--- a/cli/src/project.rs
+++ b/cli/src/project.rs
@@ -1,5 +1,6 @@
 mod cache;
 mod config_file;
+mod dependencies;
 mod filehash;
 mod parse;
 

--- a/cli/src/project/dependencies.rs
+++ b/cli/src/project/dependencies.rs
@@ -1,0 +1,59 @@
+use eyre::eyre;
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use toml_edit::Item;
+
+type Dependency = (String, Item);
+type DependencyGroups = HashMap<String, Vec<Dependency>>;
+
+/// Parsed lambda dependency groups from the embedded CLI's Cargo.toml
+static LAMBDA_DEPENDENCIES: Lazy<Result<DependencyGroups, String>> = Lazy::new(|| {
+    // Embedded Cargo.toml is parsed at compile-time and stored as a static string
+    let manifest: toml_edit::DocumentMut =
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+            .parse()
+            .map_err(|err| format!("Failed to parse embedded Cargo.toml: {err}"))?;
+
+    let groups = manifest["package"]["metadata"]["kinetics"]["dependencies"]
+        .as_table()
+        .ok_or("Missing package.metadata.kinetics.dependencies in embedded Cargo.toml")?;
+
+    groups
+        .iter()
+        .map(|(group_name, group)| {
+            let group = group.as_table().ok_or_else(|| {
+                format!("Expected lambda dependency group {group_name} to be a table")
+            })?;
+
+            let dependencies = group
+                .iter()
+                .map(|(name, dependency)| (name.to_string(), dependency.clone()))
+                .collect();
+
+            Ok((group_name.to_string(), dependencies))
+        })
+        .collect()
+});
+
+/// Inserts a lambda dependency group into the lambda's Cargo.toml dependencies section
+pub fn insert_lambda_dependency_group(
+    doc: &mut toml_edit::DocumentMut,
+    group: &str,
+) -> eyre::Result<()> {
+    let groups = LAMBDA_DEPENDENCIES.as_ref().map_err(|err| eyre!("{err}"))?;
+
+    let group = groups
+        .get(group)
+        .ok_or_else(|| eyre!("Missing lambda dependency group {group}"))?;
+
+    let dependencies = doc["dependencies"]
+        .or_insert(toml_edit::Table::new().into())
+        .as_table_mut()
+        .ok_or_else(|| eyre!("Cargo.toml dependencies must be a table"))?;
+
+    for (name, dependency) in group {
+        dependencies.insert(name, dependency.clone());
+    }
+
+    Ok(())
+}

--- a/cli/src/project/parse.rs
+++ b/cli/src/project/parse.rs
@@ -2,6 +2,7 @@ use super::filehash::{FileHash, CHECKSUMS_FILENAME};
 use super::templates;
 use super::Project;
 use crate::function::Function;
+use crate::project::dependencies::insert_lambda_dependency_group;
 use crate::tools::config::EndpointConfig;
 use eyre::Context;
 use kinetics_parser::{Params, ParsedFunction, Parser, Role};
@@ -323,52 +324,19 @@ impl Project {
     fn deps(
         &self,
         parsed_function: &ParsedFunction,
-        is_local: bool,
+        // Local and non-local bins share one generated package manifest today,
+        // so dependency insertion must write the union needed by both variants.
+        _is_local: bool,
         doc: &mut toml_edit::DocumentMut,
     ) -> eyre::Result<()> {
-        if matches!(parsed_function.role, Role::Cron | Role::Worker)
-            || (matches!(parsed_function.role, Role::Endpoint) && is_local)
-        {
-            if let Some(serde_json) = doc["dependencies"]["serde_json"]
-                .or_insert(toml_edit::Table::new().into())
-                .as_table_mut()
-            {
-                serde_json.insert("version", toml_edit::value("1.0.149"));
-            }
-
-            if let Some(reqwest) = doc["dependencies"]["reqwest"]
-                .or_insert(toml_edit::Item::Table(toml_edit::Table::new()))
-                .as_table_mut()
-            {
-                reqwest.insert("version", toml_edit::value("0.13.1"));
-                reqwest.insert("default-features", toml_edit::value(false));
-                reqwest.insert(
-                    "features",
-                    toml_edit::Array::from_iter(["default-tls"]).into(),
-                );
-            }
-        }
+        insert_lambda_dependency_group(doc, "common")?;
 
         match parsed_function.role {
             Role::Cron | Role::Worker => {
-                doc["dependencies"]["lambda_runtime"]
-                    .or_insert(toml_edit::Table::new().into())
-                    .as_table_mut()
-                    .map(|t| t.insert("version", toml_edit::value("^1.0")));
+                insert_lambda_dependency_group(doc, "cron")?;
             }
             Role::Endpoint => {
-                doc["dependencies"]["lambda_http"]
-                    .or_insert(toml_edit::Table::new().into())
-                    .as_table_mut()
-                    .map(|t| t.insert("version", toml_edit::value("^1.0")));
-                doc["dependencies"]["http"]
-                    .or_insert(toml_edit::Table::new().into())
-                    .as_table_mut()
-                    .map(|t| t.insert("version", toml_edit::value("^1.0")));
-                doc["dependencies"]["tower"]
-                    .or_insert(toml_edit::Table::new().into())
-                    .as_table_mut()
-                    .map(|t| t.insert("version", toml_edit::value("^0")));
+                insert_lambda_dependency_group(doc, "endpoint")?;
             }
         };
 
@@ -383,34 +351,6 @@ impl Project {
                 .or_insert(toml_edit::Table::new().into())
                 .as_table_mut()
                 .map(|t| t.insert("version", kinetics_version.into()));
-        }
-
-        doc["dependencies"]["aws_lambda_events"]
-            .or_insert(toml_edit::Table::new().into())
-            .as_table_mut()
-            .map(|t| t.insert("version", toml_edit::value("1.1.2")));
-
-        doc["dependencies"]["aws-config"]
-            .or_insert(toml_edit::Table::new().into())
-            .as_table_mut()
-            .map(|t| t.insert("version", toml_edit::value("1.8.12")));
-
-        doc["dependencies"]["aws-sdk-ssm"]
-            .or_insert(toml_edit::Table::new().into())
-            .as_table_mut()
-            .map(|t| t.insert("version", toml_edit::value("1.59.0")));
-
-        doc["dependencies"]["aws-sdk-sqs"]
-            .or_insert(toml_edit::Table::new().into())
-            .as_table_mut()
-            .map(|t| t.insert("version", toml_edit::value("1.91.0")));
-
-        if let Some(tokio_dep) = doc["dependencies"]["tokio"]
-            .or_insert(toml_edit::Table::new().into())
-            .as_table_mut()
-        {
-            tokio_dep.insert("version", toml_edit::value("1.49.0"));
-            tokio_dep.insert("features", toml_edit::Array::from_iter(["full"]).into());
         }
 
         if let Some(deps_table) = doc["dependencies"].as_table_mut() {


### PR DESCRIPTION
Moves generated lambda dependency versions out of code into Cargo manifest metadata
The parser now copies dependency groups from the embedded CLI manifest 