### PR TITLE
Validate config location within a project

### DIFF
--- a/cli/src/project.rs
+++ b/cli/src/project.rs
@@ -26,7 +26,7 @@ use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use toml_edit::{value, DocumentMut, Table};
 
 /// Managing user's project
@@ -64,34 +64,64 @@ pub struct Observability {
 }
 
 impl Project {
-    fn new(path: PathBuf, name: String) -> Self {
-        let workspace = Workspace::from_path(&path, &name).ok().unwrap_or_default();
-
-        Self {
-            path,
-            workspace,
-            name,
-            url: String::new(),
-            kvdb: Vec::new(),
-            observability: None,
-            domain_name: None,
-            org: None,
-        }
-    }
-
-    fn set_observability(mut self, dd_api_key: String) -> Self {
-        self.observability = Some(Observability { dd_api_key });
-        self
-    }
-
-    fn set_kvdb(mut self, kvdb: Vec<Kvdb>) -> Self {
-        self.kvdb = kvdb;
-        self
-    }
-
     pub fn with_org(mut self, org: Option<&str>) -> Self {
         self.org = org.map(|o| o.to_string());
         self
+    }
+
+    /// Validate workspace rules for kinetics and returns relevant config.
+    ///
+    /// 1️⃣ Special case - standalone crate - deploy it anyway (with config or without).
+    ///
+    /// | root config | cwd config | other members | cwd == root? | result
+    /// |-------------|------------|---------------|--------------|-------
+    /// | 2️⃣ yes      | yes        | no            | no           | error, no config in root and members at the same time
+    /// | 2️⃣ yes      | yes        | yes           | yes          | error, no config in root and members at the same time
+    /// | 2️⃣ yes      | yes        | yes           | no           | error, no config in root and members at the same time
+    /// | 2️⃣ yes      | no         | yes           | no           | error, no config in root and members at the same time
+    /// | 3️⃣ yes      | no         | no            | yes          | deploy workspace, root config
+    /// | 3️⃣ yes      | no         | no            | no           | deploy workspace, root config
+    /// | 4️⃣ no       | no         | no            | yes          | ok, but this path eventually fails on pulling name from root Cargo.toml
+    /// | 4️⃣ no       | no         | no            | no           | deploy member, Cargo.toml name
+    /// | 5️⃣ no       | no         | yes           | yes          | error, use --project
+    /// | 5️⃣ no       | no         | yes           | no           | error, use --project
+    /// | 6️⃣ no       | yes        | no            | no           | deploy member, cwd config
+    /// | 6️⃣ no       | yes        | yes           | no           | deploy member, cwd config
+    fn config(ws: &Workspace, path: &Path) -> eyre::Result<ConfigFile> {
+        // 1. Standalone crate
+        if ws.is_standalone_crate {
+            return ConfigFile::from_path(path);
+        }
+
+        let workspace_config_exists = ConfigFile::exists(&ws.root_path);
+        let no_member_configs = ws
+            .packages
+            .iter()
+            .filter(|pkg| ConfigFile::exists(&ws.root_path.join(&pkg.relative_path)))
+            .count()
+            == 0;
+        // 2. Error on config present in root and members
+        if workspace_config_exists && !no_member_configs {
+            eyre::bail!("Workspace is not allowed to have `kinetics.toml` within its root and within its members at the same time.");
+        }
+
+        // 3. Root config
+        if workspace_config_exists {
+            return ConfigFile::from_path(&ws.root_path);
+        }
+
+        // 4. No configs - deploy the cwd crate (either root or member)
+        if no_member_configs {
+            return ConfigFile::from_path(path);
+        }
+
+        // 5. Call from root or member without config
+        if ws.root_path == path || !ConfigFile::exists(path) {
+            eyre::bail!("Current folder is not a kinetics project. From the workspace root point to a folder with kinetics.toml with --project argument");
+        }
+
+        // 6. Call from member with config
+        ConfigFile::from_path(path)
     }
 
     /// Creates a new project instance by reading `kinetics.toml` from a given file `path`
@@ -99,9 +129,23 @@ impl Project {
     /// Returns default config if kinetics.toml does not exist. In that case the name will be taken
     /// from the ` Cargo.toml ` file in the same path
     pub fn from_path(path: PathBuf) -> eyre::Result<Self> {
-        let cfg = ConfigFile::from_path(path)?;
-        // Convert the config file to a Project instance with existing trait
-        cfg.try_into()
+        let workspace = Workspace::from_path(&path)?;
+        let config = Self::config(&workspace, &path)?;
+
+        Ok(Self {
+            path: config.path,
+            name: config.project.name.clone(),
+            url: String::new(),
+            kvdb: config.kvdb.clone(),
+            observability: config.observability.as_ref().map(|observability| {
+                // Read DataDog API key from env, it's not safe to store it in kinetics config file
+                let dd_api_key = std::env::var(&observability.dd_api_key_env).unwrap_or_default();
+                Observability { dd_api_key }
+            }),
+            domain_name: config.domain.clone(),
+            org: config.project.org.clone(),
+            workspace,
+        })
     }
 
     /// Get project by name, with automatic cache management.
@@ -252,7 +296,7 @@ impl Project {
 
     /// Write the current project config to config file
     pub fn write_config(&self) -> eyre::Result<()> {
-        let config_path = self.path.join("kinetics.toml");
+        let config_path = ConfigFile::path(&self.path);
 
         let mut doc = if config_path.exists() {
             fs::read_to_string(&config_path)

--- a/cli/src/project/config_file.rs
+++ b/cli/src/project/config_file.rs
@@ -1,6 +1,5 @@
 use crate::api::projects::Kvdb;
 use crate::error::Error;
-use crate::project::Project;
 use eyre::{ContextCompat, WrapErr};
 use serde::Deserialize;
 use std::fs;
@@ -19,7 +18,7 @@ pub(super) struct ConfigFile {
     pub(super) kvdb: Vec<Kvdb>,
 
     #[serde(default)]
-    domain: Option<String>,
+    pub(super) domain: Option<String>,
 
     #[serde(skip)]
     pub(super) path: PathBuf,
@@ -38,6 +37,14 @@ pub(super) struct ObservabilitySection {
 
 /// FileConfig is the structure of kinetics.toml
 impl ConfigFile {
+    pub(super) fn path(dir: &Path) -> PathBuf {
+        dir.join("kinetics.toml")
+    }
+
+    pub(super) fn exists(dir: &Path) -> bool {
+        Self::path(dir).exists()
+    }
+
     /// Reads a `FileConfig` instance from a given directory path
     ///
     /// This function looks for a `kinetics.toml` file in the specified directory.
@@ -45,17 +52,15 @@ impl ConfigFile {
     /// configuration instead. Additionally, if the `kinetics.toml` file does not explicitly set
     /// the project name, the function will fallback to extracting the name from a `Cargo.toml`
     /// file in the same directory.
-    pub(super) fn from_path(path: PathBuf) -> eyre::Result<Self> {
-        let config_toml_path = path.join("kinetics.toml");
-
-        let Ok(toml_string) = fs::read_to_string(&config_toml_path) else {
+    pub(super) fn from_path(dir: &Path) -> eyre::Result<Self> {
+        let Ok(toml_string) = fs::read_to_string(Self::path(dir)) else {
             // Return default config if kinetics.toml is not found
             return Ok(Self {
                 project: ProjectSection {
-                    name: Self::cargo_toml_name(path.as_path())?,
+                    name: Self::cargo_toml_name(dir)?,
                     org: None,
                 },
-                path,
+                path: dir.to_owned(),
                 ..Default::default()
             });
         };
@@ -68,7 +73,7 @@ impl ConfigFile {
         ))?;
 
         // Set the path to the directory containing kinetics.toml
-        config.path = path.clone();
+        config.path = dir.to_path_buf();
 
         if let Some(observability) = config.observability.as_ref() {
             if observability.dd_api_key_env.is_empty() {
@@ -84,7 +89,7 @@ impl ConfigFile {
             return Ok(config);
         }
 
-        config.project.name = Self::cargo_toml_name(path.as_path())?;
+        config.project.name = Self::cargo_toml_name(dir)?;
         Ok(config)
     }
 
@@ -116,30 +121,5 @@ impl ConfigFile {
             .to_string();
 
         Ok(name)
-    }
-}
-
-impl TryFrom<ConfigFile> for Project {
-    type Error = eyre::Report;
-
-    fn try_from(cfg: ConfigFile) -> eyre::Result<Self> {
-        let mut project = Project::new(cfg.path, cfg.project.name).set_kvdb(cfg.kvdb);
-
-        if let Some(observability) = cfg.observability {
-            // Read DataDog API key from env, it's not safe to store it in kinetics config file
-            let dd_api_key = std::env::var(&observability.dd_api_key_env).unwrap_or_default();
-
-            project = project.set_observability(dd_api_key);
-        }
-
-        if let Some(domain) = cfg.domain {
-            project.domain_name = Some(domain);
-        }
-
-        if cfg.project.org.is_some() {
-            project = project.with_org(cfg.project.org.as_deref());
-        }
-
-        Ok(project)
     }
 }

--- a/cli/src/project/parse.rs
+++ b/cli/src/project/parse.rs
@@ -54,12 +54,7 @@ impl Project {
         // If the project is a single package at the workspace root,
         // create a new manifest with [workspace] section.
         // Otherwise, read and update the existing workspace manifest.
-        let is_plain_crate = self.workspace.packages.len() == 1
-            && self.workspace.packages[0]
-                .relative_path
-                .to_str()
-                .is_some_and(|p| p.is_empty());
-        let mut workspace_doc = if is_plain_crate {
+        let mut workspace_doc = if self.workspace.is_standalone_crate {
             toml_edit::DocumentMut::from(toml_edit::Table::from_iter([(
                 "workspace",
                 toml_edit::Table::new(),

--- a/cli/src/project/workspace.rs
+++ b/cli/src/project/workspace.rs
@@ -1,8 +1,7 @@
+use crate::project::ConfigFile;
 use cargo_metadata::MetadataCommand;
 use kinetics_parser::Package;
 use std::path::{Path, PathBuf};
-
-use crate::project::ConfigFile;
 
 // Workspace definition for a project.
 //
@@ -13,126 +12,58 @@ use crate::project::ConfigFile;
 #[derive(Debug, Default, Clone)]
 pub struct Workspace {
     pub root_path: PathBuf,
+    pub is_standalone_crate: bool,
     pub packages: Vec<Package>,
 }
 
 impl Workspace {
-    pub fn from_path(path: &Path, project_name: &str) -> eyre::Result<Self> {
+    pub fn from_path(path: &Path) -> eyre::Result<Self> {
         let metadata = MetadataCommand::new().current_dir(path).exec()?;
-        // Convert [cargo_metadata::Package] into a simpler representation
-        // keeping only necessary data (in order to avoid these transforms at consuming code):
-        // - the name from Cargo.toml or the resolved project name for standalone/member projects
-        // - the relative path from workspace root to the package dir.
-        //
-        // The closure is used instead of impl From
-        // in order to access metadata from outer scope.
-        let convert_package =
-            |pkg: &cargo_metadata::Package, name: Option<&str>| -> Option<Package> {
-                Some(Package {
-                    name: name.map(String::from).or_else(|| {
-                        ConfigFile::cargo_toml_name(pkg.manifest_path.parent()?.as_std_path()).ok()
-                    })?,
-                    relative_path: pkg
-                        .manifest_path
-                        .strip_prefix(&metadata.workspace_root)
-                        .ok()?
-                        .parent()? // Remove filename and keep only the dir name.
-                        .into(),
-                })
-            };
-
-        // Validate workspace rules for kinetics:
-        // 1. Workspace as a single kinetics project:
-        //  - the workspace root MUST contain kinetics.toml;
-        //  - workspace members cannot have kinetics.toml - throw an error.
-        // 2. Standalone kinetics project:
-        //  - the project can contain kinetics.toml;
-        //  - for the name fall back to Cargo.toml.
-        // 3. Workspace member is a kinetics project:
-        //  - workspace member from where the command is called MUST have kinetics.toml.
-        //  - the workspace root cannot have kinetics.toml - throw an error.
-        let workspace_config = metadata.workspace_root.join("kinetics.toml");
-
-        // Option 3. A call within a workspace member which is a kinetics project
-        if metadata.workspace_root != path && path.join("kinetics.toml").exists() {
-            if workspace_config.exists() {
-                eyre::bail!("Workspace is not allowed to have `kinetics.toml` within its root and within its members at the same time.");
-            }
-
-            // Return `Workspace` with only one package in the `packages` list - current project.
-            let cwd_manifest = path.join("Cargo.toml");
-            return Ok(Self {
-                packages: metadata
-                    .workspace_members
-                    .into_iter()
-                    .filter_map(|member| {
-                        metadata
-                            .packages
-                            .iter()
-                            .find(|pkg| pkg.id == member)
-                            .and_then(|pkg| {
-                                // Take only the member corresponding to cwd - current project
-                                // and discard all other members.
-                                if pkg.manifest_path == cwd_manifest {
-                                    convert_package(pkg, Some(project_name))
-                                } else {
-                                    None
-                                }
-                            })
-                    })
-                    .collect(),
-                root_path: metadata.workspace_root.into_std_path_buf(),
-            });
-        }
-
-        // Options 1 and 2. A call from root.
-        let members_configs: Vec<_> = metadata
+        let root_path = metadata.workspace_root.as_std_path();
+        let packages: Vec<Package> = metadata
             .workspace_members
-            .iter()
+            .into_iter()
             .filter_map(|member| {
                 metadata
                     .packages
                     .iter()
-                    .find(|pkg| pkg.id == *member)
-                    .and_then(|pkg| pkg.manifest_path.parent())
-                    .and_then(|dir| {
-                        let config = dir.join("kinetics.toml");
-                        if config.exists() {
-                            Some(config)
-                        } else {
-                            None
-                        }
+                    .find(|pkg| pkg.id == member)
+                    // Convert [cargo_metadata::Package] into a simpler representation
+                    // keeping only necessary data (in order to avoid these transforms at consuming code):
+                    // - the name from Cargo.toml or the resolved project name for standalone/member projects
+                    // - the relative path from workspace root to the package dir.
+                    //
+                    // The closure is used instead of impl From
+                    // in order to access metadata from outer scope.
+                    .and_then(|pkg: &cargo_metadata::Package| -> Option<Package> {
+                        Some(Package {
+                            relative_path: pkg
+                                .manifest_path
+                                .strip_prefix(root_path)
+                                .ok()?
+                                .parent()? // Remove filename and keep only the dir name.
+                                .into(),
+                            name: ConfigFile::from_path(pkg.manifest_path.parent()?.as_std_path())
+                                .ok()?
+                                .project
+                                .name,
+                        })
                     })
             })
             .collect();
 
-        // For a standalone crate workspace construct errors if kinetics.toml exists.
+        // For a standalone crate Workspace construct errors if kinetics.toml exists.
         // The reason is that in this case the config is present at root and in the member
         // (since they are the same entity), and a check for no config conflicts fails.
-        let is_standalone_crate = members_configs.len() == 1
-            && members_configs
+        let is_standalone_crate = packages.len() == 1
+            && packages
                 .first()
-                .is_some_and(|c| *c == workspace_config);
-
-        if !is_standalone_crate && workspace_config.exists() && !members_configs.is_empty() {
-            eyre::bail!("Workspace is not allowed to have `kinetics.toml` within its root and within its members at the same time.");
-        }
+                .is_some_and(|pkg| root_path.join(&pkg.relative_path) == root_path);
 
         Ok(Self {
-            packages: metadata
-                .workspace_members
-                .into_iter()
-                .filter_map(|member| {
-                    metadata
-                        .packages
-                        .iter()
-                        .find(|pkg| pkg.id == member)
-                        .and_then(|pkg| {
-                            convert_package(pkg, is_standalone_crate.then_some(project_name))
-                        })
-                })
-                .collect(),
-            root_path: metadata.workspace_root.into_std_path_buf(),
+            packages,
+            root_path: root_path.into(),
+            is_standalone_crate,
         })
     }
 }


### PR DESCRIPTION
- Removed validation from Workspace and thus simplified it.
- Remove conversion from ConfigFile to Project.
- Moved all validation logic into Project::config and extended it per recent agreements.
- Project now is in charge of creating Workspace, ConfigFile, perform all validation.