### PR TITLE
Implement remote invocation

### DIFF
--- a/api/src/func.rs
+++ b/api/src/func.rs
@@ -1,3 +1,4 @@
+pub mod invoke;
 pub mod logs;
 pub mod stats;
 pub mod status;

--- a/api/src/func/invoke.rs
+++ b/api/src/func/invoke.rs
@@ -1,0 +1,25 @@
+use crate::project::Project;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Request {
+    pub project: Project,
+    pub function_name: String,
+    /// Payload is set only for worker invocation.
+    pub payload: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Status {
+    NotStarted(String),
+    Success,
+    Fail(String),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Response {
+    pub status: Status,
+    pub log: Option<String>,
+    /// Response or an error.
+    pub payload: Option<Vec<u8>>,
+}

--- a/cli/src/commands/invoke/remote.rs
+++ b/cli/src/commands/invoke/remote.rs
@@ -14,10 +14,20 @@ use std::str::FromStr;
 impl InvokeRunner<'_> {
     /// Resolve function name into URL and call it remotely
     pub async fn remote(&mut self, function: Function) -> eyre::Result<()> {
-        if function.role == Role::Endpoint {
-            self.endpoint(function).await
-        } else {
-            self.worker_or_cron(function).await
+        match function.role {
+            Role::Endpoint => self.endpoint(function).await,
+            Role::Cron => self.worker_or_cron(function).await,
+            Role::Worker => {
+                if self.command.payload.is_none() {
+                    return Err(Error::new(
+                        "No payload",
+                        Some("--payload argument is required with workers"),
+                    )
+                    .into());
+                }
+
+                self.worker_or_cron(function).await
+            }
         }
     }
 

--- a/cli/src/commands/invoke/remote.rs
+++ b/cli/src/commands/invoke/remote.rs
@@ -1,17 +1,27 @@
 use crate::commands::invoke::InvokeRunner;
+use crate::error::Error;
 use crate::function::Function;
 use crate::project::Project;
 use crate::runner::Runner;
 use color_eyre::owo_colors::OwoColorize;
 use eyre::WrapErr;
+use kinetics_api::func;
+use kinetics_parser::Role;
 use serde_json::json;
 use std::collections::HashMap;
 use std::str::FromStr;
 
 impl InvokeRunner<'_> {
     /// Resolve function name into URL and call it remotely
-    #[allow(clippy::too_many_arguments)]
-    pub async fn remote(&self, function: &Function) -> eyre::Result<()> {
+    pub async fn remote(&mut self, function: Function) -> eyre::Result<()> {
+        if function.role == Role::Endpoint {
+            self.endpoint(function).await
+        } else {
+            self.worker_or_cron(function).await
+        }
+    }
+
+    async fn endpoint(&self, function: Function) -> eyre::Result<()> {
         let project = self.project(&self.command.project).await?;
         let display_path = format!(
             "{}/{}/src/bin/{}.rs",
@@ -96,6 +106,102 @@ impl InvokeRunner<'_> {
         self.writer
             .json(json!({"status": status.as_u16(), "response": response_text}))
             .map_err(|e| eyre::eyre!(e))?;
+
+        Ok(())
+    }
+
+    async fn worker_or_cron(&mut self, function: Function) -> eyre::Result<()> {
+        let project = self.project(&self.command.project).await?;
+        let client = self.api_client().await?;
+
+        self.writer.text(&format!(
+            "\nInvoke {}...\n\n",
+            console::style(&function.name).bold()
+        ))?;
+
+        let response = client
+            .post("/function/invoke")
+            .json(&func::invoke::Request {
+                project: project.into(),
+                function_name: function.name,
+                payload: match function.role {
+                    Role::Worker => self.command.payload.take(),
+                    Role::Cron => None,
+                    _ => unreachable!(),
+                },
+            })
+            .send()
+            .await
+            .wrap_err("Failed to send invoke request")
+            .map_err(|e| self.server_error(Some(e.into())))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or("Unknown error".to_string());
+            eyre::bail!("Failed to invoke the function ({status}): {error_text}");
+        }
+
+        let body: func::invoke::Response = response.json().await.wrap_err(Error::new(
+            "Invalid response from server",
+            Some("Try again later."),
+        ))?;
+
+        log::debug!("Invoke response: {body:?}");
+
+        if let Some(log) = body.log {
+            self.writer.text(&format!(
+                "Function logs:\n{}\n",
+                console::style(log).yellow(),
+            ))?;
+        }
+
+        match body.status {
+            func::invoke::Status::NotStarted(error) => {
+                self.writer
+                    .error(&format!("Function not invoked: {error}"))?;
+                self.writer
+                    .json(json!({"invoked": false, "error": body.payload}))?;
+            }
+            func::invoke::Status::Success => {
+                self.writer.text("Function invoked\n")?;
+                self.writer
+                    .text(&format!("{}", console::style("Success\n").green()))?;
+
+                if let Some(payload) = &body.payload {
+                    self.writer.text(&format!(
+                        "{}",
+                        console::style(
+                            &String::from_utf8(payload.clone())
+                                .unwrap_or_else(|_e| "Not a string".into())
+                        )
+                        .yellow(),
+                    ))?;
+                }
+
+                self.writer
+                    .json(json!({"invoked": true, "success": true, "payload": body.payload}))?;
+            }
+            func::invoke::Status::Fail(error) => {
+                self.writer.text("Function invoked\n")?;
+                self.writer
+                    .error(&format!("{} ({})\n", console::style("Error").red(), error))?;
+                self.writer.text(&format!(
+                    "{}",
+                    console::style(
+                        &String::from_utf8(
+                            body.payload
+                                .clone()
+                                .unwrap_or_else(|| "Empty payload".into())
+                        )
+                        .unwrap_or_else(|_e| "Not a string".into())
+                    )
+                    .yellow(),
+                ))?;
+
+                self.writer
+                    .json(json!({"invoked": true, "success": false, "payload": body.payload}))?;
+            }
+        }
 
         Ok(())
     }

--- a/cli/src/commands/invoke/runner.rs
+++ b/cli/src/commands/invoke/runner.rs
@@ -19,24 +19,24 @@ impl Runner for InvokeRunner<'_> {
 
         let function = Function::find_by_name(&all_functions, &self.command.name)?;
 
-        // If --with_migrations was not passed, or comes with default "" value, then
-        // do not set the migrations path. There is a default value set down the flow.
-        let migrations_path = if self
-            .command
-            .with_migrations
-            .clone()
-            .unwrap_or_default()
-            .is_empty()
-        {
-            None
-        } else {
-            self.command.with_migrations.clone()
-        };
-
         if !self.command.remote {
+            // If --with_migrations was not passed, or comes with default "" value, then
+            // do not set the migrations path. There is a default value set down the flow.
+            let migrations_path = if self
+                .command
+                .with_migrations
+                .clone()
+                .unwrap_or_default()
+                .is_empty()
+            {
+                None
+            } else {
+                self.command.with_migrations.clone()
+            };
+
             self.local(&function, migrations_path.as_deref()).await?
         } else {
-            self.remote(&function).await?
+            self.remote(function).await?
         }
 
         Ok(())

--- a/parser/src/function.rs
+++ b/parser/src/function.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Display, path::PathBuf};
 
 /// The kind of function
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Role {
     Endpoint,
     Cron,


### PR DESCRIPTION
The remote logic applies only to worker and cron payloads (endpoint remote invocation is unchanged).

Handle three major cases:
- backend failed to invoke the function (e.g. concurrency limit exceeded);
- function invoked and succeeded;
- function invoked and failed at some point.