### PR TITLE
Request multi function statuses

### DIFF
--- a/api/src/func/status.rs
+++ b/api/src/func/status.rs
@@ -2,14 +2,37 @@ use crate::project::Project;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum FunctionName {
+    Single(String),
+    List(Vec<String>),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Request {
     pub project: Project,
-    pub function_name: String,
+    pub function_name: FunctionName,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SingleFunctionStatus {
+    Modified(String),
+    NotModified,
+    NotFound,
+    Error(String),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum FunctionStatus {
+    Single(SingleFunctionStatus),
+    List(Vec<SingleFunctionStatus>),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Response {
     /// The date and time that the function was last updated
     /// in ISO-8601 format (YYYY-MM-DDThh:mm:ss.sTZD).
-    pub last_modified: Option<String>,
+    pub last_modified: FunctionStatus,
 }

--- a/cli/src/commands/func/list.rs
+++ b/cli/src/commands/func/list.rs
@@ -1,5 +1,6 @@
 use crate::api::client::Client;
 use crate::error::Error;
+use crate::function::status;
 use crate::function::Function;
 use crate::project::Project;
 use crate::runner::{Runnable, Runner};
@@ -200,17 +201,20 @@ impl ListRunner<'_> {
             return Ok(());
         }
 
-        for parsed_function in self.functions.clone() {
-            let function = Function::new(&project, &parsed_function)?;
+        let functions = self
+            .functions
+            .iter()
+            .map(|f| Function::new(&project, f))
+            .collect::<eyre::Result<Vec<_>>>()?;
 
-            let last_modified = function
-                .status(client)
-                .await?
-                .unwrap_or_else(|| "NA".into());
+        let statuses = status(client, &project, &functions).await?;
 
-            let func_path = parsed_function.to_string();
+        for (i, function) in functions.into_iter().enumerate() {
+            let func_path = self.functions[i].to_string();
+            // Expect server to return the same length vector with the same order.
+            let last_modified = statuses[i].clone();
 
-            match parsed_function.params {
+            match function.params {
                 Params::Endpoint(params) => {
                     endpoint_rows.push(EndpointRow {
                         function: format_function_and_path(&function.name, &func_path),

--- a/cli/src/function.rs
+++ b/cli/src/function.rs
@@ -163,7 +163,7 @@ impl Function {
             .post("/function/status")
             .json(&func::status::Request {
                 project: (&self.project).into(),
-                function_name: self.name.clone(),
+                function_name: func::status::FunctionName::Single(self.name.clone()),
             })
             .send()
             .await
@@ -173,35 +173,83 @@ impl Function {
                 Some("Try again in a few seconds."),
             ))?;
 
-        let status_code = result.status();
-
-        // If the status code is 404, the function is not found or not deployed yet
-        if status_code == StatusCode::NOT_FOUND {
-            log::debug!(
-                "Function not found or not deployed yet: {}/{}",
-                self.project.name,
-                self.name
-            );
-
-            return Ok(None);
-        }
-
-        if status_code != StatusCode::OK {
-            return Err(Error::new(
-                &format!(
-                    "Function status request failed for {}/{}",
-                    self.project.name.clone(),
-                    self.name.clone()
-                ),
-                Some("Try again in a few seconds."),
-            )
-            .into());
-        }
-
-        let status: func::status::Response =
+        let result: func::status::Response =
             result.json().await.wrap_err("Failed to parse response")?;
 
-        Ok(status.last_modified)
+        match result.last_modified {
+            func::status::FunctionStatus::Single(status) => match status {
+                func::status::SingleFunctionStatus::Modified(dt) => Ok(Some(dt)),
+                func::status::SingleFunctionStatus::NotModified => Ok(None),
+                func::status::SingleFunctionStatus::NotFound => {
+                    log::debug!(
+                        "Function not found or not deployed yet: {}/{}",
+                        self.project.name,
+                        self.name
+                    );
+
+                    Ok(None)
+                }
+                func::status::SingleFunctionStatus::Error(e) => Err(Error::new(
+                    &format!(
+                        "Function status request failed for {}/{}",
+                        self.project.name, self.name
+                    ),
+                    Some(&e),
+                )
+                .into()),
+            },
+            func::status::FunctionStatus::List(_) => Err(Error::new(
+                &format!(
+                    "Unexpected response for function {}/{} status",
+                    self.project.name, self.name
+                ),
+                Some("Please report a bug at support@deploykinetics.com"),
+            )
+            .into()),
+        }
+    }
+}
+
+/// Get from the backend deployment status of multiple functions
+pub async fn status(
+    client: &Client,
+    project: &Project,
+    functions: &[Function],
+) -> eyre::Result<Vec<String>> {
+    let result = client
+        .post("/function/status")
+        .json(&func::status::Request {
+            project: project.into(),
+            function_name: func::status::FunctionName::List(
+                functions.iter().map(|f| f.name.to_owned()).collect(),
+            ),
+        })
+        .send()
+        .await
+        .inspect_err(|err| log::error!("{err:?}"))
+        .wrap_err(Error::new(
+            "Network request failed",
+            Some("Try again in a few seconds."),
+        ))?;
+
+    let result: func::status::Response =
+        result.json().await.wrap_err("Failed to parse response")?;
+
+    match result.last_modified {
+        func::status::FunctionStatus::Single(_) => Err(Error::new(
+            &format!("Unexpected response for {} functions status", project.name),
+            Some("Please report a bug at support@deploykinetics.com"),
+        )
+        .into()),
+        func::status::FunctionStatus::List(items) => Ok(items
+            .into_iter()
+            .map(|status| match status {
+                func::status::SingleFunctionStatus::Modified(dt) => dt,
+                func::status::SingleFunctionStatus::NotModified => "Not modified".to_string(),
+                func::status::SingleFunctionStatus::NotFound => "Not found".to_string(),
+                func::status::SingleFunctionStatus::Error(e) => format!("Error {e}"),
+            })
+            .collect()),
     }
 }
 


### PR DESCRIPTION
This change is aimed at optimizing the speed of `func list --verbose` command, which is quite slow for large projects.

- Switch `/function/status` endpoint to requesting statuses of all functions in one request. The old logic remains, though it's not used anywhere for now - endpoint is capable of handling both cases.
- Instead of relying on status codes, the returned status list contains this information for each function. Expect HTTP status of 200 or fail entire batch.
