### PR TITLE
Add payload-file argument for the invoke command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,6 +2364,7 @@ dependencies = [
  "sqlx",
  "syn",
  "tabled",
+ "tempfile",
  "terminal_size",
  "time",
  "tokio",
@@ -4379,6 +4380,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -202,10 +202,11 @@ Print out all available functions before deployment. Their names and URLs of RES
 kinetics func list
 ```
 
-Invoke a function locally with parameters. `--payload` sets the JSON body payload for endpoint and worker functions:
+Invoke a function with JSON using `--payload` or `--payload-file`; worker payloads must be arrays, with one message per item:
 
 ```sh
-kinetics invoke BasicWorkerWorker --payload '{"name": "John"}'
+kinetics invoke BasicWorkerWorker --payload '[{"name": "John"}, {"name": "Jane"}]'
+kinetics invoke BasicEndpointEndpoint --payload-file endpoint-payload.json
 ```
 
 Invoke endpoint with http headers:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -64,6 +64,7 @@ sqlx = { version = "0.8.6", features = [
 ] }
 syn = { version = "2.0", features = ["full", "visit"] }
 tabled = "0.20.0"
+tempfile = "3.27.0"
 terminal_size = "0.4.4"
 tokio = { workspace = true, features = ["full"] }
 toml = { workspace = true }

--- a/cli/src/commands/invoke.rs
+++ b/cli/src/commands/invoke.rs
@@ -33,7 +33,7 @@ pub(crate) struct InvokeCommand {
     ///
     /// For an endpoint, the payload is sent unchanged in the request body.
     /// For a worker, the payload must be a JSON array. Each array item becomes
-    /// the body of an individual worker message.
+    /// the body of an individual worker message. If omitted, an empty array is used.
     ///
     /// Example: --payload '[{"name": "John"}]'
     #[arg(short, long, conflicts_with = "payload_file")]

--- a/cli/src/commands/invoke.rs
+++ b/cli/src/commands/invoke.rs
@@ -29,14 +29,23 @@ pub(crate) struct InvokeCommand {
     #[arg(long)]
     url_path: Option<String>,
 
-    /// Must be a valid JSON.
+    /// JSON payload for an endpoint or worker.
     ///
-    /// In case of endpoint functions payload is a body.
-    /// In case of workers, payload is a single event of a queue, which will be wrapped in array and passed to worker function.
+    /// For an endpoint, the payload is sent unchanged in the request body.
+    /// For a worker, the payload must be a JSON array. Each array item becomes
+    /// the body of an individual worker message.
     ///
-    /// Example: --payload '{"name": "John Smith"}'
-    #[arg(short, long)]
+    /// Example: --payload '[{"name": "John"}]'
+    #[arg(short, long, conflicts_with = "payload_file")]
     payload: Option<String>,
+
+    /// Read the JSON payload from a file.
+    ///
+    /// Uses the same role-specific format as --payload.
+    ///
+    /// Example: --payload-file payload.json
+    #[arg(long, value_name = "PATH")]
+    payload_file: Option<PathBuf>,
 
     /// Invoke function remotely. Only works if function was deployed before.
     #[arg(short, long)]

--- a/cli/src/commands/invoke/local.rs
+++ b/cli/src/commands/invoke/local.rs
@@ -10,6 +10,7 @@ use color_eyre::owo_colors::OwoColorize;
 use eyre::WrapErr;
 use serde_json::json;
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
@@ -21,6 +22,27 @@ impl InvokeRunner<'_> {
         function: &Function,
         migrations_path: Option<&str>,
     ) -> eyre::Result<()> {
+        let payload = self.resolve_payload(&function.role)?;
+
+        // Pass the payload through a temporary file to avoid process environment size limits.
+        let payload_file = payload
+            .as_deref()
+            .map(|payload| {
+                let mut file = tempfile::NamedTempFile::new()
+                    .wrap_err("Failed to create temporary payload file")?;
+
+                file.write_all(payload.as_bytes())
+                    .wrap_err("Failed to write temporary payload file")?;
+
+                let temp_path = file.into_temp_path();
+                let absolute_path = temp_path
+                    .canonicalize()
+                    .wrap_err("Failed to resolve temporary payload file path")?;
+
+                Ok::<_, eyre::Error>((temp_path, absolute_path))
+            })
+            .transpose()?;
+
         let project = self.project(&self.command.project).await?;
         let mut secrets_envs = HashMap::new();
 
@@ -94,16 +116,14 @@ impl InvokeRunner<'_> {
         }
 
         // Start the command with piped stdout and stderr
-        let child = Command::new("cargo")
+        let mut command = Command::new("cargo");
+
+        command
             .args(["run", "--bin", &format!("{}Local", function.name)])
             .envs(secrets_envs)
             .envs(aws_credentials)
             .envs(local_environment)
             .envs(function.environment())
-            .env(
-                "KINETICS_INVOKE_PAYLOAD",
-                self.command.payload.clone().unwrap_or("{}".into()),
-            )
             .env(
                 "KINETICS_INVOKE_HEADERS",
                 self.command.headers.clone().unwrap_or("{}".into()),
@@ -114,9 +134,14 @@ impl InvokeRunner<'_> {
             )
             .current_dir(&invoke_dir)
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .wrap_err("Failed to execute cargo run")?;
+            .stderr(Stdio::piped());
+
+        // Keep the TempPath alive until invocation completes so the file is not deleted on drop.
+        if let Some((_, absolute_path)) = payload_file.as_ref() {
+            command.arg("--").arg(absolute_path.as_os_str());
+        }
+
+        let child = command.spawn().wrap_err("Failed to execute cargo run")?;
 
         let mut process = Process::new(child, self.writer);
         let status = process.log()?;

--- a/cli/src/commands/invoke/remote.rs
+++ b/cli/src/commands/invoke/remote.rs
@@ -16,22 +16,15 @@ impl InvokeRunner<'_> {
     pub async fn remote(&mut self, function: Function) -> eyre::Result<()> {
         match function.role {
             Role::Endpoint => self.endpoint(function).await,
-            Role::Cron => self.worker_or_cron(function).await,
-            Role::Worker => {
-                if self.command.payload.is_none() {
-                    return Err(Error::new(
-                        "No payload",
-                        Some("--payload argument is required with workers"),
-                    )
-                    .into());
-                }
-
-                self.worker_or_cron(function).await
-            }
+            Role::Cron | Role::Worker => self.worker_or_cron(function).await,
         }
     }
 
     async fn endpoint(&self, function: Function) -> eyre::Result<()> {
+        let payload = self
+            .resolve_payload(&function.role)?
+            .expect("endpoint payload is always resolved");
+
         let project = self.project(&self.command.project).await?;
         let display_path = format!(
             "{}/{}/src/bin/{}.rs",
@@ -94,7 +87,7 @@ impl InvokeRunner<'_> {
         let response = client
             .post(url)
             .headers(headers_map)
-            .body(self.command.payload.clone().unwrap_or_else(|| "{}".into()))
+            .body(payload)
             .send()
             .await
             .wrap_err("Failed to call function URL")?;
@@ -121,6 +114,7 @@ impl InvokeRunner<'_> {
     }
 
     async fn worker_or_cron(&mut self, function: Function) -> eyre::Result<()> {
+        let payload = self.resolve_payload(&function.role)?;
         let project = self.project(&self.command.project).await?;
         let client = self.api_client().await?;
 
@@ -135,7 +129,7 @@ impl InvokeRunner<'_> {
                 project: project.into(),
                 function_name: function.name,
                 payload: match function.role {
-                    Role::Worker => self.command.payload.take(),
+                    Role::Worker => payload,
                     Role::Cron => None,
                     _ => unreachable!(),
                 },

--- a/cli/src/commands/invoke/runner.rs
+++ b/cli/src/commands/invoke/runner.rs
@@ -66,14 +66,9 @@ impl InvokeRunner<'_> {
 
         // Resolve the final payload based on the role
         let resolved_payload = match role {
-            Role::Endpoint => Some(payload.unwrap_or_else(|| "{}".into())),
+            Role::Endpoint => Some(payload.unwrap_or("{}".to_string())),
             Role::Worker => {
-                let payload = payload.ok_or_else(|| {
-                    Error::new(
-                        "No payload",
-                        Some("--payload or --payload-file is required with workers"),
-                    )
-                })?;
+                let payload = payload.unwrap_or("[]".to_string());
 
                 serde_json::from_str::<Vec<Value>>(&payload)
                     .wrap_err("Worker payload must be a top-level JSON array")?;

--- a/cli/src/commands/invoke/runner.rs
+++ b/cli/src/commands/invoke/runner.rs
@@ -3,6 +3,10 @@ use crate::error::Error;
 use crate::function::Function;
 use crate::runner::Runner;
 use crate::writer::Writer;
+use eyre::WrapErr;
+use kinetics_parser::Role;
+use serde_json::Value;
+use std::fs;
 
 pub(crate) struct InvokeRunner<'a> {
     pub(crate) command: InvokeCommand,
@@ -40,5 +44,48 @@ impl Runner for InvokeRunner<'_> {
         }
 
         Ok(())
+    }
+}
+
+impl InvokeRunner<'_> {
+    /// Resolves and validates the invocation payload for the function role.
+    pub(super) fn resolve_payload(&self, role: &Role) -> eyre::Result<Option<String>> {
+        // Construct payload from either the payload string or the payload file if any is provided
+        let payload = match self.command.payload.as_deref() {
+            Some(payload) => Some(payload.to_owned()),
+            None => self
+                .command
+                .payload_file
+                .as_deref()
+                .map(|p| {
+                    fs::read_to_string(p)
+                        .wrap_err_with(|| format!("Failed to read payload file {}", p.display()))
+                })
+                .transpose()?,
+        };
+
+        // Resolve the final payload based on the role
+        let resolved_payload = match role {
+            Role::Endpoint => Some(payload.unwrap_or_else(|| "{}".into())),
+            Role::Worker => {
+                let payload = payload.ok_or_else(|| {
+                    Error::new(
+                        "No payload",
+                        Some("--payload or --payload-file is required with workers"),
+                    )
+                })?;
+
+                serde_json::from_str::<Vec<Value>>(&payload)
+                    .wrap_err("Worker payload must be a top-level JSON array")?;
+
+                Some(payload)
+            }
+            Role::Cron if payload.is_some() => {
+                eyre::bail!("Cron functions do not accept a payload");
+            }
+            Role::Cron => None,
+        };
+
+        Ok(resolved_payload)
     }
 }

--- a/cli/src/project/templates/endpoint.rs
+++ b/cli/src/project/templates/endpoint.rs
@@ -37,10 +37,22 @@ pub fn endpoint(
                     }}
                 }}
 
-                let payload = match std::env::var(\"KINETICS_INVOKE_PAYLOAD\") {{
-                    Ok(val) => val,
-                    Err(_) => \"{{}}\".into(),
-                }};
+                let payload_path = std::env::args_os().nth(1).ok_or_else(|| {{
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        \"Payload file path is required as the first argument\",
+                    )
+                }})?;
+
+                let payload = std::fs::read_to_string(&payload_path).map_err(|err| {{
+                    std::io::Error::new(
+                        err.kind(),
+                        format!(
+                            \"Failed to read payload file '{{}}': {{err}}\",
+                            std::path::Path::new(&payload_path).display(),
+                        ),
+                    )
+                }})?;
 
                 let headers_json = match std::env::var(\"KINETICS_INVOKE_HEADERS\") {{
                     Ok(val) => val,

--- a/cli/src/project/templates/worker.rs
+++ b/cli/src/project/templates/worker.rs
@@ -18,17 +18,48 @@ pub fn worker(import_statement: &str, rust_function_name: &str, is_local: bool) 
                     }}
                 }}
 
-                // Get the payload from environment variables
-                let payload = match std::env::var(\"KINETICS_INVOKE_PAYLOAD\") {{
-                    Ok(val) => val,
-                    Err(_) => \"{{}}\".into(),
-                }};
+                let payload_path = std::env::args_os().nth(1).ok_or_else(|| {{
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        \"Payload file path is required as the first argument\",
+                    )
+                }})?;
 
-                let mut sqs_message = SqsMessage::default();
-                sqs_message.message_id = Some(\"test\".into());
-                sqs_message.body = Some(payload);
+                let payload = std::fs::read_to_string(&payload_path).map_err(|err| {{
+                    std::io::Error::new(
+                        err.kind(),
+                        format!(
+                            \"Failed to read payload file '{{}}': {{err}}\",
+                            std::path::Path::new(&payload_path).display(),
+                        ),
+                    )
+                }})?;
+
+                let payloads: Vec<serde_json::Value> = serde_json::from_str(&payload).map_err(|err| {{
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            \"Failed to parse worker payload file '{{}}' as a JSON array: {{err}}\",
+                            std::path::Path::new(&payload_path).display(),
+                        ),
+                    )
+                }})?;
+
+                let mut records = Vec::with_capacity(payloads.len());
+                for (index, payload) in payloads.into_iter().enumerate() {{
+                    let mut sqs_message = SqsMessage::default();
+                    sqs_message.message_id = Some(format!(\"test-{{}}\", index + 1));
+                    sqs_message.body = Some(serde_json::to_string(&payload).map_err(|err| {{
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!(\"Failed to serialize worker payload item {{}}: {{err}}\", index + 1),
+                        )
+                    }})?);
+                    records.push(sqs_message);
+                }}
+
                 let mut sqs_event = SqsEvent::default();
-                sqs_event.records = vec![sqs_message];
+                sqs_event.records = records;
 
                 // Convert SqsEvent to LambdaEvent<SqsEvent>
                 let context = lambda_runtime::Context::default();

--- a/examples/src/basic/worker.rs
+++ b/examples/src/basic/worker.rs
@@ -20,6 +20,7 @@ pub async fn worker(
     _config: &KineticsConfig,
 ) -> Result<QueueRetries, BoxError> {
     let mut retries = QueueRetries::new();
+    println!("Got batch of {} records", records.len());
 
     let first_record = match records.first() {
         Some(record) => record,

--- a/examples/src/basic/worker.rs
+++ b/examples/src/basic/worker.rs
@@ -8,10 +8,11 @@ use tower::BoxError;
 
 /// A queue worker
 ///
-/// Always returns the first record as failed to process. It will then be retried.
+/// Processes and prints every record in the input batch.
+/// Always returns only the first record as failed to process. It will then be retried.
 ///
 /// Test locally with the following command:
-/// kinetics invoke BasicWorkerWorker --payload '{"name": "John"}'
+/// kinetics invoke BasicWorkerWorker --payload '[{"name": "John"}, {"name": "Jane"}]'
 #[worker(fifo = true, batch_size = 2)]
 pub async fn worker(
     records: Vec<QueueRecord>,
@@ -20,7 +21,7 @@ pub async fn worker(
 ) -> Result<QueueRetries, BoxError> {
     let mut retries = QueueRetries::new();
 
-    let record = match records.first() {
+    let first_record = match records.first() {
         Some(record) => record,
         None => {
             return Err(Box::new(std::io::Error::new(
@@ -30,12 +31,15 @@ pub async fn worker(
         }
     };
 
-    let body = serde_json::Value::from(record.body.clone().unwrap());
-    println!("Got body: {body:?}");
+    // Process every record in the input batch.
+    for record in &records {
+        let body = serde_json::Value::from(record.body.clone().unwrap());
+        println!("Got message: {body:?}");
+    }
 
-    // Optionally return the first record from the input batch in retries, just for example
+    // Optionally return only the first record from the input batch in retries, just for example
     // Doing so will force the worker to process the item again on the next iteration
-    retries.add(&record.message_id.clone().unwrap_or_default());
+    retries.add(&first_record.message_id.clone().unwrap_or_default());
 
     Ok(retries)
 }


### PR DESCRIPTION
- Add `--payload-file` support for local and remote endpoint and worker invocations
- Pass local payloads through temporary files to avoid process environment size limits
- Support worker payload arrays with one message per item and use an empty `[]` when the payload is omitted