### PR TITLE
Add readable project-scoped AWS resource names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics-api"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "chrono",
  "humantime",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics-lib"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "aws-config",
  "aws-sdk-dsql",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics-macro"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "kinetics-parser",
  "syn",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "kinetics-parser"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "color-eyre",
  "http 1.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ resolver = "2"
 members = ["api", "cli", "examples", "lib", "macro", "parser"]
 
 [workspace.package]
-version = "0.17.5"
+version = "0.17.6"
 
 [workspace.dependencies]
-kinetics-api = { path = "api", version = "0.17.5" }
-kinetics-lib = { path = "lib", version = "0.17.5" }
-kinetics-macro = { path = "macro", version = "0.17.5" }
-kinetics-parser = { path = "parser", version = "0.17.5" }
+kinetics-api = { path = "api", version = "0.17.6" }
+kinetics-lib = { path = "lib", version = "0.17.6" }
+kinetics-macro = { path = "macro", version = "0.17.6" }
+kinetics-parser = { path = "parser", version = "0.17.6" }
 
 # Do not upgrade as TOML parsing fails
 toml = "=0.8.23"

--- a/lib/src/tools.rs
+++ b/lib/src/tools.rs
@@ -2,6 +2,121 @@ pub mod config;
 pub mod http;
 pub mod queue;
 
+/// Namespace included in project resource hash inputs.
+const RESOURCE_NAMESPACE: &str = "kinetics";
+const PROJECT_HASH_LENGTH: usize = 16;
+const RESOURCE_HASH_LENGTH: usize = 12;
+const PROJECT_RESOURCE_NAME_MAX_LENGTH: usize = 64;
+
+/// Type of physical resource scoped to a project.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum ProjectResourceKind {
+    /// Primary SQS queue.
+    Queue,
+    /// SQS dead-letter queue.
+    DeadLetterQueue,
+    /// SSM parameter containing a project secret.
+    Secret,
+    /// Lambda function.
+    Lambda,
+}
+
+impl ProjectResourceKind {
+    /// Short identifier used in physical resource names.
+    fn token(self) -> &'static str {
+        match self {
+            Self::Queue => "q",
+            Self::DeadLetterQueue => "d",
+            Self::Secret => "s",
+            Self::Lambda => "l",
+        }
+    }
+
+    /// Canonical kind name included in the hash input.
+    fn canonical_name(self) -> &'static str {
+        match self {
+            Self::Queue => "main-queue",
+            Self::DeadLetterQueue => "dead-letter-queue",
+            Self::Secret => "secret",
+            Self::Lambda => "lambda",
+        }
+    }
+}
+
+/// Returns a deterministic hash segment of the requested length for a resource scope or identity.
+fn resource_hash(
+    owner_id: &str,
+    project_name: &str,
+    kind: ProjectResourceKind,
+    resource_name: Option<&str>,
+    hash_length: usize,
+) -> String {
+    let mut name = format!(
+        "{RESOURCE_NAMESPACE}-{owner_id}-{project_name}-{}",
+        kind.canonical_name()
+    );
+
+    if let Some(resource_name) = resource_name {
+        name.push('-');
+        name.push_str(resource_name);
+    }
+
+    sha256::digest(name).chars().take(hash_length).collect()
+}
+
+/// Returns the common prefix for a resource kind, owner, and project.
+pub fn project_resource_prefix(
+    kind: ProjectResourceKind,
+    owner_id: &str,
+    project_name: &str,
+) -> String {
+    format!(
+        "{}-{}-",
+        kind.token(),
+        resource_hash(owner_id, project_name, kind, None, PROJECT_HASH_LENGTH)
+    )
+}
+
+/// Returns a physical resource name composed of project and resource hashes and a readable suffix.
+///
+/// The suffix contains only ASCII alphanumeric characters, and the complete name is at most
+/// 64 bytes.
+pub fn project_resource_name(
+    kind: ProjectResourceKind,
+    owner_id: &str,
+    project_name: &str,
+    resource_name: &str,
+) -> String {
+    let prefix = project_resource_prefix(kind, owner_id, project_name);
+
+    let resource_hash = resource_hash(
+        owner_id,
+        project_name,
+        kind,
+        Some(resource_name),
+        RESOURCE_HASH_LENGTH,
+    );
+
+    let readable_name_max_length =
+        PROJECT_RESOURCE_NAME_MAX_LENGTH.saturating_sub(prefix.len() + resource_hash.len() + 1);
+
+    let readable_name = resource_name
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(readable_name_max_length)
+        .collect::<String>();
+
+    let mut resource_name = format!("{prefix}{resource_hash}");
+
+    if !readable_name.is_empty() {
+        resource_name.push('-');
+        resource_name.push_str(&readable_name);
+    }
+
+    resource_name
+}
+
 /// Unique resource name
 ///
 /// Construct a readable name by escaping non-ascii chars, and appending a hash of

--- a/lib/src/tools/queue.rs
+++ b/lib/src/tools/queue.rs
@@ -1,4 +1,4 @@
-use crate::tools::{config::Config as KineticsConfig, resource_name};
+use crate::tools::{config::Config as KineticsConfig, project_resource_name, ProjectResourceKind};
 use aws_lambda_events::sqs::{BatchItemFailure, SqsBatchResponse, SqsEvent};
 use aws_sdk_sqs::operation::send_message::builders::SendMessageFluentBuilder;
 use eyre::OptionExt;
@@ -117,7 +117,8 @@ impl Client {
                 // out of user and project names
                 let queue_name = std::env::var("KINETICS_QUEUE_NAME")
                     .or_else(|_| {
-                        Ok::<String, std::env::VarError>(resource_name(
+                        Ok::<String, std::env::VarError>(project_resource_name(
+                            ProjectResourceKind::Queue,
                             &std::env::var("KINETICS_USERNAME")
                                 .expect("KINETICS_USERNAME is not set"),
                             &project_name,


### PR DESCRIPTION
Adds shared helpers for deterministic, kind-specific resource names with stable project
  prefixes, collision-resistant hashes, and readable suffixes.