### PR TITLE
Refactor output coloring

### DIFF
--- a/cli/src/commands/auth/logout.rs
+++ b/cli/src/commands/auth/logout.rs
@@ -35,8 +35,8 @@ impl Runner for LogoutRunner<'_> {
         credentials.delete()?;
 
         self.writer.text(&format!(
-            "{}\n",
-            console::style("Successfully logged out").green().bold()
+            "{} logged out\n",
+            console::style("Successfully").bold()
         ))?;
 
         self.writer.json(json!({ "success": true }))?;

--- a/cli/src/commands/auth/tokens/create.rs
+++ b/cli/src/commands/auth/tokens/create.rs
@@ -36,8 +36,8 @@ impl Runner for CreateRunner<'_> {
     /// Creates a new authentication token
     async fn run(&mut self) -> Result<(), Error> {
         self.writer.text(&format!(
-            "\n{}...\n",
-            console::style("Requesting new access token").bold().green()
+            "\n{} new access token...\n",
+            console::style("Requesting").bold()
         ))?;
 
         let client = self.api_client().await?;

--- a/cli/src/commands/auth/tokens/delete.rs
+++ b/cli/src/commands/auth/tokens/delete.rs
@@ -40,7 +40,7 @@ impl Runner for DeleteRunner<'_> {
         if !self.writer.is_structured() {
             self.writer.text(&format!(
                 "\nDelete access token {}? {} ",
-                self.command.name.clone().bold(),
+                self.command.name.clone(),
                 "[y/N]".dim()
             ))?;
 
@@ -63,8 +63,8 @@ impl Runner for DeleteRunner<'_> {
         }
 
         self.writer.text(&format!(
-            "\n{}...\n",
-            console::style("Deleting access token").bold().green()
+            "\n{} access token...\n",
+            console::style("Deleting").bold()
         ))?;
 
         let client = self.api_client().await?;
@@ -103,7 +103,7 @@ impl Runner for DeleteRunner<'_> {
         }
 
         self.writer
-            .text(&format!("\n{}\n", console::style("Deleted").green().bold()))?;
+            .text(&format!("\n{}\n", console::style("Deleted").bold()))?;
 
         self.writer.json(json!({"success": true}))?;
         Ok(())

--- a/cli/src/commands/auth/tokens/list.rs
+++ b/cli/src/commands/auth/tokens/list.rs
@@ -25,8 +25,8 @@ impl Runner for ListRunner<'_> {
         let client = self.api_client().await?;
 
         self.writer.text(&format!(
-            "\n{}...\n\n",
-            console::style("Fetching access tokens").bold().green()
+            "\n{} access tokens...\n\n",
+            console::style("Fetching").bold()
         ))?;
 
         let response = client
@@ -76,7 +76,7 @@ impl Runner for ListRunner<'_> {
 
             self.writer.text(&format!(
                 "{}\n{}\n\n",
-                console::style(&token.name).bold(),
+                console::style(&token.name),
                 console::style(format!(
                     "Expires at {}",
                     expires_at_local.format("%d %b %Y %H:%M:%S")

--- a/cli/src/commands/cicd/github.rs
+++ b/cli/src/commands/cicd/github.rs
@@ -69,9 +69,7 @@ pub fn workflow(project: &Project, is_silent: bool, writer: &Writer) -> eyre::Re
         return Err(Error::new(
             &format!(
                 "Workflow already exists\n{}",
-                console::style(deploy_workflow_path.to_string_lossy())
-                    .bold()
-                    .underlined(),
+                console::style(deploy_workflow_path.to_string_lossy()).underlined(),
             ),
             None,
         )
@@ -90,7 +88,6 @@ pub fn workflow(project: &Project, is_silent: bool, writer: &Writer) -> eyre::Re
             "\n{}\n{}\n\n{}\n{}\n",
             console::style("Added CI/CD config files at").dim(),
             console::style(deploy_workflow_path.to_string_lossy())
-                .bold()
                 .underlined(),
             console::style("CI/CD docs available at").yellow(),
             console::style(

--- a/cli/src/commands/cicd/init.rs
+++ b/cli/src/commands/cicd/init.rs
@@ -38,8 +38,8 @@ impl Runner for InitRunner<'_> {
         let project = self.project(&self.command.project).await?;
 
         self.writer.text(&format!(
-            "{}\n",
-            console::style("Creating GitHub workflow...").bold().green()
+            "{} GitHub workflow...\n",
+            console::style("Creating").bold()
         ))?;
 
         if self.command.github {
@@ -48,7 +48,7 @@ impl Runner for InitRunner<'_> {
         }
 
         self.writer
-            .text(&format!("{}\n", console::style("Done").bold().green()))?;
+            .text(&format!("{}\n", console::style("Done").bold()))?;
 
         self.writer.json(json!({"success": true}))?;
         Ok(())

--- a/cli/src/commands/deploy/runner.rs
+++ b/cli/src/commands/deploy/runner.rs
@@ -61,8 +61,8 @@ impl DeployRunner<'_> {
     /// Deploy only environment variables for functions
     async fn deploy_envs(&mut self, project: Project) -> eyre::Result<()> {
         self.writer.text(&format!(
-            "{}...\n",
-            console::style("Provisioning envs").green().bold()
+            "{} envs...\n",
+            console::style("Provisioning").bold()
         ))?;
 
         let client = self.api_client().await?;
@@ -77,7 +77,7 @@ impl DeployRunner<'_> {
         if functions.is_empty() {
             self.writer.text(&format!(
                 "{}\n",
-                console::style("No functions found").yellow().bold()
+                console::style("No functions found").yellow()
             ))?;
 
             return Ok(());
@@ -98,7 +98,7 @@ impl DeployRunner<'_> {
 
             self.writer.text(&format!(
                 "{} {}\n",
-                console::style(function.name.clone()).bold(),
+                function.name,
                 if envs_string.is_empty() {
                     console::style("None").dim().yellow()
                 } else {
@@ -146,7 +146,7 @@ impl DeployRunner<'_> {
         }
 
         self.writer
-            .text(&format!("{}\n", console::style("Done").green().bold()))?;
+            .text(&format!("{}\n", console::style("Done").bold()))?;
 
         Ok(())
     }

--- a/cli/src/commands/domains/add.rs
+++ b/cli/src/commands/domains/add.rs
@@ -49,9 +49,9 @@ impl Runner for AddRunner<'_> {
         }
 
         self.writer.text(&format!(
-            "\n{} {}...\n\n",
-            console::style("Adding domain").bold().green(),
-            console::style(&self.command.domain_name).bold(),
+            "\n{} domain {}...\n\n",
+            console::style("Adding").bold(),
+            console::style(&self.command.domain_name).underlined(),
         ))?;
 
         let response = client
@@ -92,7 +92,7 @@ impl Runner for AddRunner<'_> {
 
         for ns in &resp.nameservers {
             self.writer
-                .text(&format!("  {}\n", console::style(ns).bold()))?;
+                .text(&format!("  {}\n", console::style(ns).underlined()))?;
         }
 
         project.domain_name = Some(self.command.domain_name.clone());

--- a/cli/src/commands/domains/remove.rs
+++ b/cli/src/commands/domains/remove.rs
@@ -58,9 +58,9 @@ impl Runner for RemoveRunner<'_> {
         }
 
         self.writer.text(&format!(
-            "\n{} {}...\n\n",
-            console::style("Removing domain").bold().green(),
-            console::style(&domain_name).bold(),
+            "\n{} domain {}...\n\n",
+            console::style("Removing").bold(),
+            console::style(&domain_name).underlined(),
         ))?;
 
         let response = client
@@ -87,9 +87,9 @@ impl Runner for RemoveRunner<'_> {
             .map_err(|e| self.error(None, None, Some(e.into())))?;
 
         self.writer.text(&format!(
-            "{} {}\n",
-            console::style("Removed domain").bold().green(),
-            console::style(&domain_name).bold(),
+            "{} domain {}\n",
+            console::style("Removed").bold(),
+            console::style(&domain_name).underlined(),
         ))?;
 
         self.writer.json(json!({

--- a/cli/src/commands/envs/list.rs
+++ b/cli/src/commands/envs/list.rs
@@ -48,8 +48,8 @@ impl Runner for ListRunner<'_> {
 
         let envs = if self.command.remote {
             self.writer.text(&format!(
-                "{}...\n\n",
-                console::style("Fetching env vars").green().bold()
+                "{} env vars...\n\n",
+                console::style("Fetching").bold()
             ))?;
 
             remote(&project, &parsed_functions)
@@ -57,8 +57,8 @@ impl Runner for ListRunner<'_> {
                 .map_err(|e| self.server_error(Some(e.into())))?
         } else {
             self.writer.text(&format!(
-                "{}\n\n",
-                console::style("Showing local env vars").bold().green()
+                "{} local env vars\n\n",
+                console::style("Showing").bold()
             ))?;
 
             local(&project)
@@ -93,9 +93,9 @@ impl Runner for ListRunner<'_> {
                 .to_string();
 
             self.writer.text(&format!(
-                "{} {}\n",
-                function_name.as_str().bold(),
-                format!("from {}", path).dim()
+                "{function_name} {} {}\n",
+                "from".dim(),
+                path.dim().underlined()
             ))?;
 
             envs_json.insert(function_name.clone(), json!(env_vars));

--- a/cli/src/commands/func/list.rs
+++ b/cli/src/commands/func/list.rs
@@ -132,7 +132,7 @@ impl ListRunner<'_> {
 
         if !endpoints.is_empty() {
             self.writer
-                .text(&format!("\n{}\n\n", "Endpoints".bold().green()))
+                .text(&format!("\n{}\n\n", "Endpoints".bold()))
                 .map_err(|e| eyre::eyre!(e))?;
 
             endpoints.iter().try_for_each(|f| self.display_simple(f))?;
@@ -140,7 +140,7 @@ impl ListRunner<'_> {
 
         if !workers.is_empty() {
             self.writer
-                .text(&format!("\n{}\n\n", "Workers".bold().green()))
+                .text(&format!("\n{}\n\n", "Workers".bold()))
                 .map_err(|e| eyre::eyre!(e))?;
 
             workers.iter().try_for_each(|f| self.display_simple(f))?;
@@ -148,7 +148,7 @@ impl ListRunner<'_> {
 
         if !crons.is_empty() {
             self.writer
-                .text(&format!("\n{}\n\n", "Crons".bold().green()))
+                .text(&format!("\n{}\n\n", "Crons".bold()))
                 .map_err(|e| eyre::eyre!(e))?;
 
             crons.iter().try_for_each(|f| self.display_simple(f))?;
@@ -255,7 +255,7 @@ impl ListRunner<'_> {
             table.with(Style::modern()).with(settings.clone());
 
             self.writer
-                .text(&format!("Endpoints\n{}\n", table))
+                .text(&format!("{}\n{}\n", "Endpoints".bold(), table))
                 .map_err(|e| eyre::eyre!(e))?;
         }
 
@@ -264,7 +264,7 @@ impl ListRunner<'_> {
             table.with(Style::modern()).with(settings.clone());
 
             self.writer
-                .text(&format!("Crons:\n{}\n", table))
+                .text(&format!("{}\n{}\n", "Crons".bold(), table))
                 .map_err(|e| eyre::eyre!(e))?;
         }
 
@@ -272,7 +272,7 @@ impl ListRunner<'_> {
             let mut table = Table::new(worker_rows.to_vec());
             table.with(Style::modern()).with(settings);
             self.writer
-                .text(&format!("Workers:\n{}\n", table))
+                .text(&format!("{}\n{}\n", "Workers".bold(), table))
                 .map_err(|e| eyre::eyre!(e))?;
         }
 
@@ -321,7 +321,7 @@ impl ListRunner<'_> {
         self.writer
             .text(&format!(
                 "{} {}\n",
-                function.func_name(false)?.bold(),
+                function.func_name(false)?,
                 function.to_string().dimmed(),
             ))
             .map_err(|e| eyre::eyre!(e))?;

--- a/cli/src/commands/func/logs.rs
+++ b/cli/src/commands/func/logs.rs
@@ -65,10 +65,10 @@ impl Runner for LogsRunner<'_> {
         let client = self.api_client().await?;
 
         self.writer.text(&format!(
-            "\n{} {} {}...\n\n",
-            console::style("Fetching logs").bold().green(),
+            "\n{} logs {} {}...\n\n",
+            console::style("Fetching").bold(),
             console::style("for").dim(),
-            console::style(&function.name).bold()
+            console::style(&function.name)
         ))?;
 
         let response = client

--- a/cli/src/commands/func/stats.rs
+++ b/cli/src/commands/func/stats.rs
@@ -57,10 +57,10 @@ impl Runner for StatsRunner<'_> {
         let client = self.api_client().await?;
 
         self.writer.text(&format!(
-            "\n{} {} {}...\n\n",
-            console::style("Fetching stats").bold().green(),
+            "\n{} stats {} {}...\n\n",
+            console::style("Fetching").bold(),
             console::style("for").dim(),
-            console::style(&function.name).bold()
+            function.name
         ))?;
 
         let response = client

--- a/cli/src/commands/func/toggle.rs
+++ b/cli/src/commands/func/toggle.rs
@@ -85,8 +85,8 @@ impl Runner for ToggleRunner<'_> {
 
         self.writer.text(&format!(
             "\n{} {}...\n\n",
-            console::style(format!("{}", self.op)).bold().green(),
-            console::style(&function.name).bold()
+            console::style(format!("{}", self.op)).bold(),
+            function.name
         ))?;
 
         let response = client
@@ -109,7 +109,7 @@ impl Runner for ToggleRunner<'_> {
         match response.status() {
             status if status.is_success() => {
                 self.writer
-                    .text(&format!("{}\n", console::style("Done").bold().green()))?;
+                    .text(&format!("{}\n", console::style("Done").bold()))?;
 
                 self.writer
                     .json(json!({"success": true, "is_throttled": is_throttled}))?;

--- a/cli/src/commands/init/runner.rs
+++ b/cli/src/commands/init/runner.rs
@@ -48,10 +48,10 @@ impl<'a> Runner for InitRunner<'a> {
         self.set_dir()?;
 
         self.writer.text(&format!(
-            "\n{} {} {}...\n",
-            console::style("Starting project").green().bold(),
+            "\n{} project {} {}...\n",
+            console::style("Starting").bold(),
             console::style("in").dim(),
-            console::style(&self.dir.to_string_lossy()).bold()
+            console::style(&self.dir.to_string_lossy()).underlined()
         ))?;
 
         // Create project directory
@@ -166,7 +166,7 @@ impl<'a> Runner for InitRunner<'a> {
         }
 
         self.writer
-            .text(&format!("{}\n", console::style("Done").bold().green()))?;
+            .text(&format!("{}\n", console::style("Done").bold()))?;
 
         self.writer.json(json!({"success": true}))?;
         Ok(())

--- a/cli/src/commands/invoke/local.rs
+++ b/cli/src/commands/invoke/local.rs
@@ -61,10 +61,10 @@ impl InvokeRunner<'_> {
 
         self.writer
             .text(&format!(
-                "\n{} {} {}...\n",
-                console::style("Invoking function").green().bold(),
+                "\n{} function {} {}...\n",
+                console::style("Invoking").bold(),
                 console::style("from").dimmed(),
-                console::style(&display_path).underlined().bold()
+                console::style(&display_path).underlined()
             ))
             .map_err(|e| eyre::eyre!(e))?;
 

--- a/cli/src/commands/invoke/remote.rs
+++ b/cli/src/commands/invoke/remote.rs
@@ -120,7 +120,7 @@ impl InvokeRunner<'_> {
 
         self.writer.text(&format!(
             "\n{} {}...\n\n",
-            console::style("Invoke").bold(),
+            console::style("Invoking").bold(),
             function.name
         ))?;
 

--- a/cli/src/commands/invoke/remote.rs
+++ b/cli/src/commands/invoke/remote.rs
@@ -35,10 +35,10 @@ impl InvokeRunner<'_> {
 
         self.writer
             .text(&format!(
-                "\n{} {} {}...\n",
-                console::style("Invoking remote function").green().bold(),
+                "\n{} remote function {} {}...\n",
+                console::style("Invoking").bold(),
                 console::style("from").dimmed(),
-                console::style(&display_path).underlined().bold()
+                console::style(&display_path).underlined()
             ))
             .map_err(|e| eyre::eyre!(e))?;
 
@@ -119,8 +119,9 @@ impl InvokeRunner<'_> {
         let client = self.api_client().await?;
 
         self.writer.text(&format!(
-            "\nInvoke {}...\n\n",
-            console::style(&function.name).bold()
+            "\n{} {}...\n\n",
+            console::style("Invoke").bold(),
+            function.name
         ))?;
 
         let response = client
@@ -169,7 +170,7 @@ impl InvokeRunner<'_> {
             func::invoke::Status::Success => {
                 self.writer.text("Function invoked\n")?;
                 self.writer
-                    .text(&format!("{}", console::style("Success\n").green()))?;
+                    .text(&format!("{}\n", console::style("Success").bold()))?;
 
                 if let Some(payload) = &body.payload {
                     self.writer.text(&format!(

--- a/cli/src/commands/login/runner.rs
+++ b/cli/src/commands/login/runner.rs
@@ -49,16 +49,14 @@ impl Runner for LoginRunner {
         }
 
         println!(
-            "{} {} {}",
+            "{} logged in via {}",
             console::style(if is_new_session {
-                "Successfully logged in"
+                "Successfully"
             } else {
-                "Already logged in"
+                "Already"
             })
-            .green()
             .bold(),
-            console::style("via").dim(),
-            console::style(&self.command.email).underlined().bold()
+            console::style(&self.command.email).underlined()
         );
 
         Ok(())

--- a/cli/src/commands/migrations/apply.rs
+++ b/cli/src/commands/migrations/apply.rs
@@ -49,12 +49,10 @@ impl<'a> Runner for ApplyRunner<'a> {
         }
 
         self.writer.text(&format!(
-            "{} {} {}...\n\n",
-            console::style("Applying migrations").green().bold(),
+            "{} migrations {} {}...\n\n",
+            console::style("Applying").bold(),
             console::style("from").dim(),
-            console::style(format!("{}", migrations_path.to_string_lossy()))
-                .underlined()
-                .bold(),
+            console::style(format!("{}", migrations_path.to_string_lossy())).underlined(),
         ))?;
 
         let response = client
@@ -95,7 +93,7 @@ impl<'a> Runner for ApplyRunner<'a> {
             .map_err(|e| self.server_error(Some(e.into())))?;
 
         self.writer
-            .text(&format!("\n{}\n", console::style("Done").green().bold()))?;
+            .text(&format!("\n{}\n", console::style("Done").bold()))?;
 
         self.writer.json(json!({"success": true}))?;
         Ok(())

--- a/cli/src/commands/orgs/create.rs
+++ b/cli/src/commands/orgs/create.rs
@@ -30,8 +30,8 @@ impl Runner for CreateRunner<'_> {
         let client = self.api_client().await?;
 
         self.writer.text(&format!(
-            "{}...\n",
-            console::style("Creating new org").bold().green()
+            "{} new org...\n",
+            console::style("Creating").bold()
         ))?;
 
         let response: Response = client
@@ -45,7 +45,7 @@ impl Runner for CreateRunner<'_> {
             .map_err(|e| self.server_error(Some(e.into())))?;
 
         self.writer
-            .text(&format!("{}\n", console::style("Done").green()))?;
+            .text(&format!("{}\n", console::style("Done").bold()))?;
 
         self.writer
             .json(json!({"success": true, "org": {"id": response.id, "name": name}}))?;

--- a/cli/src/commands/orgs/delete.rs
+++ b/cli/src/commands/orgs/delete.rs
@@ -55,7 +55,7 @@ impl Runner for DeleteRunner<'_> {
         if !self.writer.is_structured() {
             self.writer.text(&format!(
                 "\nAre you sure want to delete org {}? {} ",
-                name.clone().white().bold(),
+                name.clone().white(),
                 "[y/N]".dim()
             ))?;
 
@@ -77,10 +77,8 @@ impl Runner for DeleteRunner<'_> {
             }
         }
 
-        self.writer.text(&format!(
-            "\n{}...\n",
-            console::style("Deleting org").bold().green()
-        ))?;
+        self.writer
+            .text(&format!("\n{} org...\n", console::style("Deleting").bold()))?;
 
         let delete_response: Response = client
             .request(
@@ -93,7 +91,7 @@ impl Runner for DeleteRunner<'_> {
             .map_err(|e| self.server_error(Some(e.into())))?;
 
         self.writer
-            .text(&format!("\n{}\n", console::style("Done").green().bold()))?;
+            .text(&format!("\n{}\n", console::style("Done").bold()))?;
 
         self.writer
             .json(json!({"success": true, "org": {"id": delete_response.id, "name": name}}))?;

--- a/cli/src/commands/orgs/leave.rs
+++ b/cli/src/commands/orgs/leave.rs
@@ -42,7 +42,7 @@ impl Runner for LeaveRunner<'_> {
         if !self.writer.is_structured() {
             self.writer.text(&format!(
                 "\nAre you sure you want to leave org {}? {} ",
-                org.clone().white().bold(),
+                org.clone().white(),
                 "[y/N]".dim()
             ))?;
 
@@ -65,9 +65,8 @@ impl Runner for LeaveRunner<'_> {
         }
 
         self.writer.text(&format!(
-            "\n{} {}...\n",
-            console::style("Leaving the org").bold().green(),
-            console::style(&org).bold(),
+            "\n{} the org {org}...\n",
+            console::style("Leaving").bold(),
         ))?;
 
         client
@@ -80,7 +79,7 @@ impl Runner for LeaveRunner<'_> {
             .await?;
 
         self.writer
-            .text(&format!("\n{}\n", console::style("Done").green().bold()))?;
+            .text(&format!("\n{}\n", console::style("Done").bold()))?;
 
         self.writer
             .json(json!({"success": true, "org": {"name": org}}))?;

--- a/cli/src/commands/orgs/list.rs
+++ b/cli/src/commands/orgs/list.rs
@@ -20,8 +20,8 @@ struct ListRunner<'a> {
 impl Runner for ListRunner<'_> {
     async fn run(&mut self) -> Result<(), Error> {
         self.writer.text(&format!(
-            "\n{}...\n\n",
-            console::style("Fetching orgs").bold().green()
+            "\n{} orgs...\n\n",
+            console::style("Fetching").bold()
         ))?;
 
         let client = self.api_client().await?;
@@ -41,7 +41,7 @@ impl Runner for ListRunner<'_> {
 
         for org in &response.orgs {
             self.writer
-                .text(&format!("{}", console::style(&org.name).white().bold(),))?;
+                .text(&format!("{}", console::style(&org.name).white()))?;
 
             for member in &org.members {
                 self.writer.text(&format!(

--- a/cli/src/commands/orgs/members/delete.rs
+++ b/cli/src/commands/orgs/members/delete.rs
@@ -46,8 +46,8 @@ impl Runner for DeleteMemberRunner<'_> {
         if !self.writer.is_structured() {
             self.writer.text(&format!(
                 "\nAre you sure you want to remove {} from {}? {} ",
-                username.clone().white().bold(),
-                org.clone().white().bold(),
+                username.clone().white(),
+                org.clone().white(),
                 "[y/N]".dim()
             ))?;
 
@@ -70,8 +70,8 @@ impl Runner for DeleteMemberRunner<'_> {
         }
 
         self.writer.text(&format!(
-            "\n{}...\n",
-            console::style("Removing member").bold().green()
+            "\n{} member...\n",
+            console::style("Removing").bold()
         ))?;
 
         client
@@ -85,7 +85,7 @@ impl Runner for DeleteMemberRunner<'_> {
             .await?;
 
         self.writer
-            .text(&format!("\n{}\n", console::style("Done").green().bold()))?;
+            .text(&format!("\n{}\n", console::style("Done").bold()))?;
 
         self.writer
             .json(json!({"success": true, "org": org, "username": username}))?;

--- a/cli/src/commands/orgs/members/invite.rs
+++ b/cli/src/commands/orgs/members/invite.rs
@@ -35,11 +35,10 @@ impl Runner for InviteMemberRunner<'_> {
         let client = self.api_client().await?;
 
         self.writer.text(&format!(
-            "\n{} {} {} {}...\n\n",
-            console::style("Inviting").bold().green(),
-            console::style(&email).bold(),
-            console::style("to").bold().green(),
-            console::style(&org).bold()
+            "\n{} {} {} {org}...\n\n",
+            console::style("Inviting").bold(),
+            console::style(&email).underlined(),
+            console::style("to").dim()
         ))?;
 
         client
@@ -54,7 +53,7 @@ impl Runner for InviteMemberRunner<'_> {
 
         self.writer.text(&format!(
             "Invitation has been sent. Please ask the person to check email.\n\n{}\n",
-            console::style("Done").green().bold()
+            console::style("Done").bold()
         ))?;
 
         self.writer

--- a/cli/src/commands/orgs/owners/add.rs
+++ b/cli/src/commands/orgs/owners/add.rs
@@ -35,11 +35,11 @@ impl Runner for AddOwnerRunner<'_> {
         let client = self.api_client().await?;
 
         self.writer.text(&format!(
-            "\n{} {} {} {}...\n",
-            console::style("Adding").bold().green(),
-            console::style(&username).bold(),
-            console::style("as an owner of").bold().green(),
-            console::style(&org).bold()
+            "\n{} {} {} owner {} {org}...\n",
+            console::style("Adding").bold(),
+            console::style(&username).underlined(),
+            console::style("as an").dim(),
+            console::style("of").dim(),
         ))?;
 
         client
@@ -53,7 +53,7 @@ impl Runner for AddOwnerRunner<'_> {
             .await?;
 
         self.writer
-            .text(&format!("\n{}\n", console::style("Done").green().bold()))?;
+            .text(&format!("\n{}\n", console::style("Done").bold()))?;
 
         self.writer
             .json(json!({"success": true, "org": org, "email": username}))?;

--- a/cli/src/commands/orgs/owners/delete.rs
+++ b/cli/src/commands/orgs/owners/delete.rs
@@ -47,8 +47,8 @@ impl Runner for DeleteOwnerRunner<'_> {
         if !self.writer.is_structured() {
             self.writer.text(&format!(
                 "\nAre you sure you want to demote {} from being an owner of {}? {} ",
-                username.clone().white().bold(),
-                org.clone().white().bold(),
+                username.clone().white(),
+                org.clone().white(),
                 "[y/N]".dim()
             ))?;
 
@@ -71,8 +71,8 @@ impl Runner for DeleteOwnerRunner<'_> {
         }
 
         self.writer.text(&format!(
-            "\n{}...\n",
-            console::style("Demoting owner").bold().green()
+            "\n{} owner...\n",
+            console::style("Demoting").bold()
         ))?;
 
         let request = Request {
@@ -89,7 +89,7 @@ impl Runner for DeleteOwnerRunner<'_> {
             .await?;
 
         self.writer
-            .text(&format!("\n{}\n", console::style("Done").green().bold()))?;
+            .text(&format!("\n{}\n", console::style("Done").bold()))?;
 
         self.writer
             .json(json!({"success": true, "org": org, "username": username}))?;

--- a/cli/src/commands/proj/destroy.rs
+++ b/cli/src/commands/proj/destroy.rs
@@ -61,7 +61,7 @@ impl Runner for DestroyRunner<'_> {
         if !self.writer.is_structured() {
             self.writer.text(&format!(
                 "You are destroying \"{}\" project.\n",
-                project.name.as_str().blue().bold()
+                project.name.as_str().blue()
             ))?;
             self.writer.text(&format!(
                 "{} {}: ",
@@ -97,10 +97,8 @@ impl Runner for DestroyRunner<'_> {
             .wrap_err("Project destroy request failed")
             .map_err(|e| self.server_error(Some(e.into())))?;
 
-        self.writer.text(&format!(
-            "{}\n",
-            console::style("Project destroyed").green()
-        ))?;
+        self.writer
+            .text(&format!("Project {}\n", console::style("destroyed").bold()))?;
 
         Project::clear_cache().map_err(|e| {
             self.error(

--- a/cli/src/commands/proj/list.rs
+++ b/cli/src/commands/proj/list.rs
@@ -41,8 +41,8 @@ impl Runner for ListRunner<'_> {
         self.api_client().await?;
 
         self.writer.text(&format!(
-            "{}...\n\n",
-            console::style("Fetching projects").green().bold()
+            "{} projects...\n\n",
+            console::style("Fetching").bold()
         ))?;
 
         let project = self
@@ -70,7 +70,7 @@ impl Runner for ListRunner<'_> {
 
         for Project { name, url, .. } in &projects {
             self.writer
-                .text(&format!("{}\n{}\n\n", name.bold(), url.dimmed()))?;
+                .text(&format!("{name}\n{}\n\n", url.dimmed().underline()))?;
 
             projects_json.push(json!({"name": name, "url": url}));
         }

--- a/cli/src/commands/proj/org.rs
+++ b/cli/src/commands/proj/org.rs
@@ -67,19 +67,16 @@ impl Runner for OrgRunner<'_> {
         match self.command.org.clone() {
             Some(org) => {
                 self.writer.text(&format!(
-                    "{} {}\n",
-                    console::style("Project org set to").green().bold(),
-                    console::style(&org).bold()
+                    "{} {} {org}\n",
+                    console::style("Set").bold(),
+                    console::style("project org to").dim(),
                 ))?;
 
                 self.writer.json(json!({"success": true, "org": org}))?;
             }
             None => {
-                self.writer.text(&format!(
-                    "{} {}\n",
-                    console::style("Project org unset").green().bold(),
-                    console::style("").bold()
-                ))?;
+                self.writer
+                    .text(&format!("{} project org\n", console::style("Unset").bold()))?;
 
                 self.writer.json(json!({"success": true}))?;
             }

--- a/cli/src/commands/proj/rollback.rs
+++ b/cli/src/commands/proj/rollback.rs
@@ -91,8 +91,7 @@ impl Runner for RollbackRunner<'_> {
                 "v{} ({})",
                 target_version.version,
                 target_version.updated_at.with_timezone(&chrono::Local)
-            ))
-            .bold(),
+            )),
         ))?;
 
         client
@@ -130,7 +129,7 @@ impl Runner for RollbackRunner<'_> {
         }
 
         self.writer
-            .text(&format!("{}\n", console::style("Done").green()))?;
+            .text(&format!("{}\n", console::style("Done").bold()))?;
 
         self.writer.json(json!({"success": true}))?;
         Ok(())

--- a/cli/src/commands/proj/versions.rs
+++ b/cli/src/commands/proj/versions.rs
@@ -35,8 +35,8 @@ impl Runner for VersionsRunner<'_> {
         let client = self.api_client().await?;
 
         self.writer.text(&format!(
-            "{}...\n\n",
-            console::style("Fetching versions").green().bold()
+            "{} versions...\n\n",
+            console::style("Fetching").bold()
         ))?;
 
         let project = self.project(&self.command.project).await?;
@@ -77,7 +77,7 @@ impl Runner for VersionsRunner<'_> {
 
             self.writer.text(&format!(
                 "{} {}\n{}\n\n",
-                v.version.to_string().bold(),
+                v.version,
                 updated_at.dimmed(),
                 message
             ))?;

--- a/cli/src/migrations.rs
+++ b/cli/src/migrations.rs
@@ -123,12 +123,10 @@ impl<'a> Migrations<'a> {
             .wrap_err("Failed to create a migration file")?;
 
         self.writer.text(&format!(
-            "{} {} {}\n",
-            console::style("Created migration").green().bold(),
+            "{} migration {} {}\n",
+            console::style("Created").bold(),
             console::style("at").dim(),
-            console::style(format!("{}", filepath.to_string_lossy()))
-                .underlined()
-                .bold(),
+            console::style(filepath.to_string_lossy()).underlined(),
         ))?;
 
         Ok(())


### PR DESCRIPTION
- Remove green color from most outputs (except pipeline steps).
- Use bold mostly on status words.
- Remove bold from function names.
- Apply underline to paths and urls/mails.