### PR TITLE
Remote invoke - output payload only for workers

### DIFF
--- a/cli/src/commands/invoke/remote.rs
+++ b/cli/src/commands/invoke/remote.rs
@@ -171,16 +171,20 @@ impl InvokeRunner<'_> {
                 self.writer
                     .text(&format!("{}", console::style("Success\n").green()))?;
 
-                if let Some(payload) = &body.payload {
-                    self.writer.text(&format!(
-                        "{}",
-                        console::style(
-                            &String::from_utf8(payload.clone())
-                                .unwrap_or_else(|_e| "Not a string".into())
-                        )
-                        .yellow(),
-                    ))?;
-                }
+                match function.role {
+                    Role::Worker if let Some(payload) = &body.payload => {
+                        self.writer.text(&format!(
+                            "{}",
+                            console::style(
+                                &String::from_utf8(payload.clone())
+                                    .unwrap_or_else(|_e| "Not a string".into())
+                            )
+                            .yellow(),
+                        ))?;
+                    }
+                    // For cron no output is expected, so discard anything that arrives (e.g. "null" string).
+                    _ => (),
+                };
 
                 self.writer
                     .json(json!({"invoked": true, "success": true, "payload": body.payload}))?;


### PR DESCRIPTION
For crons there is no relevant output, so we discard any payload. Usually it contains just a "null" string bytes.